### PR TITLE
Fixed compilation when precompiled headers are disabled

### DIFF
--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -1,6 +1,7 @@
 #include "providers/seventv/SeventvEmotes.hpp"
 
 #include <QJsonArray>
+#include <QJsonDocument>
 #include <QThread>
 
 #include "common/Common.hpp"


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Currently compilation works because of precompiled headers being enabled by default. This fixes compilation if you have precompiled headers turned off by providing a missing include.