### PR TITLE
Added timeout to NetworkRequests fetching emotes

### DIFF
--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -156,6 +156,7 @@ void SeventvEmotes::loadEmotes()
     QByteArray b = QByteArray::fromStdString(str.toStdString());
 
     NetworkRequest(apiUrlGQL, NetworkRequestType::Post)
+        .timeout(30000)
         .header("Content-Type", "application/json")
         .payload(b)
         .onSuccess([this](NetworkResult result) -> Outcome {
@@ -219,6 +220,7 @@ void SeventvEmotes::loadChannel(std::weak_ptr<Channel> channel,
     QByteArray b = QByteArray::fromStdString(str.toStdString());
 
     NetworkRequest(apiUrlGQL, NetworkRequestType::Post)
+        .timeout(20000)
         .header("Content-Type", "application/json")
         .payload(b)
         .onSuccess([callback = std::move(callback), channel, &channelId,


### PR DESCRIPTION
This should prevent certain emotes from failing to load.
Following the format we sorta established on upstream - 30 seconds for `loadEmotes` and 20 seconds for `loadChannel`.
