### PR TITLE
GraphQL query cleanup

### DIFF
--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -178,30 +178,34 @@ void SeventvEmotes::loadChannel(std::weak_ptr<Channel> channel,
     qCDebug(chatterinoSeventv)
         << "Reloading 7TV Channel Emotes" << channelId << manualRefresh;
 
-    QJsonObject payload;
+    QJsonObject payload, variables;
 
-    QString query = R"({
-        user(id: "%1") {
-            emotes {
-                id
-                name
-                provider
-                provider_id
-                visibility
-                mime
-                owner {
+    QString query = R"(
+        query fetchUserEmotes($login: String!) {
+            user(id: $login) {
+                emotes {
                     id
-                    display_name
-                    login
-                    twitch_id
+                    name
+                    provider
+                    provider_id
+                    visibility
+                    mime
+                    owner {
+                        id
+                        display_name
+                        login
+                        twitch_id
+                    }
                 }
             }
-        }
-    })";
+        })";
 
-    payload.insert("query",
-                   query.arg(channelLogin).replace(whitespaceRegex, " "));
-    payload.insert("variables", {});
+    variables.insert("login", channelLogin)->toObject();
+
+    payload.insert("query", query.replace(whitespaceRegex, " "));
+    payload.insert("variables", variables);
+
+    qDebug() << QJsonDocument(payload).toJson(QJsonDocument::Compact);
 
     NetworkRequest(apiUrlGQL, NetworkRequestType::Post)
         .timeout(20000)

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -125,7 +125,7 @@ void SeventvEmotes::loadEmotes()
 {
     qCDebug(chatterinoSeventv) << "Loading 7TV Emotes";
 
-    QJsonObject payload;
+    QJsonObject payload, variables;
 
     QString query = R"({
         search_emotes(query: "", globalState: "only", limit: 150, pageSize: 150) {
@@ -171,7 +171,6 @@ void SeventvEmotes::loadEmotes()
 
 void SeventvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                                 const QString &channelId,
-                                const QString &channelLogin,
                                 std::function<void(EmoteMap &&)> callback,
                                 bool manualRefresh)
 {
@@ -181,7 +180,7 @@ void SeventvEmotes::loadChannel(std::weak_ptr<Channel> channel,
     QJsonObject payload, variables;
 
     QString query = R"(
-        query fetchUserEmotes($login: String!) {
+        query loadUserEmotes($login: String!) {
             user(id: $login) {
                 emotes {
                     id
@@ -200,7 +199,7 @@ void SeventvEmotes::loadChannel(std::weak_ptr<Channel> channel,
             }
         })";
 
-    variables.insert("login", channelLogin)->toObject();
+    variables.insert("login", channelId);
 
     payload.insert("query", query.replace(whitespaceRegex, " "));
     payload.insert("variables", variables);

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -1,9 +1,5 @@
 #include "providers/seventv/SeventvEmotes.hpp"
 
-#include <QJsonArray>
-#include <QJsonDocument>
-#include <QThread>
-
 #include "common/Common.hpp"
 #include "common/NetworkRequest.hpp"
 #include "common/QLogging.hpp"
@@ -13,16 +9,22 @@
 #include "messages/MessageBuilder.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QThread>
+
 namespace chatterino {
 namespace {
+    const QRegularExpression whitespaceRegex(R"(\s+)");
+
     const QString CHANNEL_HAS_NO_EMOTES(
         "This channel has no 7TV channel emotes.");
+    const QString emoteLinkFormat("https://7tv.app/emotes/%1");
 
-    QString emoteLinkFormat("https://7tv.app/emotes/%1");
     Url getEmoteLink(const EmoteId &id, const QString &emoteScale)
 
     {
-        static const QString urlTemplate("https://cdn.7tv.app/emote/%1/%2");
+        const QString urlTemplate("https://cdn.7tv.app/emote/%1/%2");
 
         return {urlTemplate.arg(id.string, emoteScale)};
     }
@@ -51,18 +53,15 @@ namespace {
                                       .value("display_name")
                                       .toString()};
 
-        auto emote =
-            Emote({name,
-                   ImageSet{Image::fromUrl(getEmoteLink(id, "1x"), 1),
-                            Image::fromUrl(getEmoteLink(id, "2x"), 0.66),
-                            Image::fromUrl(getEmoteLink(id, "3x"), 0.33)},
-                   Tooltip{QString("%1<br> %2 7TV Emote<br>By: %3")
-                               .arg(name.string)
-                               .arg(isGlobal ? "Global" : "Channel")
-                               .arg(author.string)
-
-                   },
-                   Url{emoteLinkFormat.arg(id.string)}});
+        auto emote = Emote(
+            {name,
+             ImageSet{Image::fromUrl(getEmoteLink(id, "1x"), 1),
+                      Image::fromUrl(getEmoteLink(id, "2x"), 0.66),
+                      Image::fromUrl(getEmoteLink(id, "3x"), 0.33)},
+             Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")
+                         .arg(name.string, (isGlobal ? "Global" : "Channel"),
+                              author.string)},
+             Url{emoteLinkFormat.arg(id.string)}});
 
         auto result = CreateEmoteResult({id, name, emote});
         return result;
@@ -73,7 +72,7 @@ namespace {
     {
         auto emotes = EmoteMap();
 
-        for (auto jsonEmote : jsonEmotes)
+        for (const auto &jsonEmote : jsonEmotes)
         {
             auto emote = createEmote(jsonEmote, true);
             emotes[emote.name] =
@@ -83,12 +82,12 @@ namespace {
         return {Success, std::move(emotes)};
     }
 
-    EmoteMap parseChannelEmotes(const QJsonObject &jsonRoot,
+    EmoteMap parseChannelEmotes(const QJsonObject &root,
                                 const QString &channelName)
     {
         auto emotes = EmoteMap();
 
-        auto jsonEmotes = jsonRoot.value("emotes").toArray();
+        auto jsonEmotes = root.value("emotes").toArray();
         for (auto jsonEmote_ : jsonEmotes)
         {
             auto jsonEmote = jsonEmote_.toObject();
@@ -124,51 +123,44 @@ boost::optional<EmotePtr> SeventvEmotes::emote(const EmoteName &name) const
 
 void SeventvEmotes::loadEmotes()
 {
-    // TODO: Network request
-    qCDebug(chatterinoSeventv) << "[7TVEmotes] Loading Emotes";
+    qCDebug(chatterinoSeventv) << "Loading 7TV Emotes";
 
-    QJsonObject body;
+    QJsonObject payload;
 
-    const char *gqlQuery = R""""(
-        {
-            search_emotes(query: "", globalState: "only", limit: 150, pageSize: 150) {
+    QString query = R"({
+        search_emotes(query: "", globalState: "only", limit: 150, pageSize: 150) {
+            id
+            name
+            provider
+            provider_id
+            visibility
+            mime
+            owner {
                 id
-                name
-                provider
-                provider_id
-                visibility
-                mime
-                owner {
-                    id
-                    display_name
-                    login
-                    twitch_id
-                }
+                display_name
+                login
+                twitch_id
             }
         }
-    )"""";
+    })";
 
-    body.insert("query", gqlQuery);
-    body.insert("variables", QJsonObject{});
-
-    QJsonDocument doc(body);
-    QString str(doc.toJson(QJsonDocument::Compact));
-    QByteArray b = QByteArray::fromStdString(str.toStdString());
+    payload.insert("query", query.replace(whitespaceRegex, " "));
+    payload.insert("variables", {});
 
     NetworkRequest(apiUrlGQL, NetworkRequestType::Post)
         .timeout(30000)
         .header("Content-Type", "application/json")
-        .payload(b)
+        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
         .onSuccess([this](NetworkResult result) -> Outcome {
             QJsonArray parsedEmotes = result.parseJson()
                                           .value("data")
                                           .toObject()
                                           .value("search_emotes")
                                           .toArray();
-            qCDebug(chatterinoSeventv) << "7TV Global Emotes:" << parsedEmotes;
+            qCDebug(chatterinoSeventv)
+                << "7TV Global Emotes" << parsedEmotes.size();
 
-            auto emotes = this->global_.get();
-            auto pair = parseGlobalEmotes(parsedEmotes, *emotes);
+            auto pair = parseGlobalEmotes(parsedEmotes, *this->global_.get());
             if (pair.first)
                 this->global_.set(
                     std::make_shared<EmoteMap>(std::move(pair.second)));
@@ -184,56 +176,51 @@ void SeventvEmotes::loadChannel(std::weak_ptr<Channel> channel,
                                 bool manualRefresh)
 {
     qCDebug(chatterinoSeventv)
-        << "[7TVEmotes] Reload 7TV Channel Emotes for channel" << channelId;
+        << "Reloading 7TV Channel Emotes" << channelId << manualRefresh;
 
-    QJsonObject body;
+    QJsonObject payload;
 
-    std::string queryStr =
-        R"(
-        {
-            user(id: "%1") {
-                emotes {
+    QString query = R"({
+        user(id: "%1") {
+            emotes {
+                id
+                name
+                provider
+                provider_id
+                visibility
+                mime
+                owner {
                     id
-                    name
-                    provider
-                    provider_id
-                    visibility
-                    mime
-                    owner {
-                        id
-                        display_name
-                        login
-                        twitch_id
-                    }
+                    display_name
+                    login
+                    twitch_id
                 }
             }
         }
-    )";
-    QString query = QString::fromStdString(queryStr).arg(channelLogin);
-    qCDebug(chatterinoSeventv) << query;
+    })";
 
-    body.insert("query", query);
-    body.insert("variables", QJsonObject{});
-
-    QJsonDocument doc(body);
-    QString str(doc.toJson(QJsonDocument::Compact));
-    QByteArray b = QByteArray::fromStdString(str.toStdString());
+    payload.insert("query",
+                   query.arg(channelLogin).replace(whitespaceRegex, " "));
+    payload.insert("variables", {});
 
     NetworkRequest(apiUrlGQL, NetworkRequestType::Post)
         .timeout(20000)
         .header("Content-Type", "application/json")
-        .payload(b)
-        .onSuccess([callback = std::move(callback), channel, &channelId,
+        .payload(QJsonDocument(payload).toJson(QJsonDocument::Compact))
+        .onSuccess([callback = std::move(callback), channel, channelId,
                     manualRefresh](NetworkResult result) -> Outcome {
             QJsonObject parsedEmotes = result.parseJson()
                                            .value("data")
                                            .toObject()
                                            .value("user")
                                            .toObject();
-            qCDebug(chatterinoSeventv) << "7TV Channel Emotes:" << parsedEmotes;
 
             auto emoteMap = parseChannelEmotes(parsedEmotes, channelId);
             bool hasEmotes = !emoteMap.empty();
+
+            qCDebug(chatterinoSeventv)
+                << "Loaded 7TV Channel Emotes" << channelId << emoteMap.size()
+                << manualRefresh;
 
             if (hasEmotes)
             {

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
-#include <memory>
 #include "boost/optional.hpp"
 #include "common/Aliases.hpp"
 #include "common/Atomic.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
+
+#include <memory>
 
 namespace chatterino {
 

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -25,7 +25,6 @@ public:
     void loadEmotes();
     static void loadChannel(std::weak_ptr<Channel> channel,
                             const QString &channelId,
-                            const QString &channelLogin,
                             std::function<void(EmoteMap &&)> callback,
                             bool manualRefresh);
 

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -247,7 +247,7 @@ void TwitchChannel::setLocalizedName(const QString &name)
 void TwitchChannel::refresh7TVChannelEmotes(bool manualRefresh)
 {
     SeventvEmotes::loadChannel(
-        weakOf<Channel>(this), this->roomId(), this->getName(),
+        weakOf<Channel>(this), this->roomId(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {
             if (auto shared = weak.lock())
                 this->seventvEmotes_.set(


### PR DESCRIPTION
- [x] Cleaned up GQL queries, removed some debug output.
- [x] Make use of proper GQL variables.
- [x] Switch to querying global emotes via Twitch user ID (instead of Twitch user login).