### PR TITLE
corrected numbering in badge slot comments

### DIFF
--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -104,7 +104,7 @@ enum class MessageElementFlag : int64_t {
     // - Seventv Subscriber
     BadgeSeventv = (1LL << 40),
 
-    // Slot 7: FrankerFaceZ
+    // Slot 8: FrankerFaceZ
     // - FFZ developer badge
     // - FFZ bot badge
     // - FFZ donator badge

--- a/src/providers/seventv/SeventvWebSocket.hpp
+++ b/src/providers/seventv/SeventvWebSocket.hpp
@@ -1,11 +1,10 @@
 #ifndef SEVENTVWEBSOCKET_H
 #define SEVENTVWEBSOCKET_H
 
-
 class SeventvWebSocket
 {
 public:
     SeventvWebSocket();
 };
 
-#endif // SEVENTVWEBSOCKET_H
+#endif  // SEVENTVWEBSOCKET_H


### PR DESCRIPTION
Slot 7 was used twice in comments (introduced by copy & paste)

Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description
#19 has a copy and paste error in the numbering of badge slots.
imho no changelog entry is needed as no functionality is changed. Just a very small clean up. :)
