### PR TITLE
Zerowidth Emotes (7TV)

### DIFF
--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -14,6 +14,7 @@ struct Emote {
     ImageSet images;
     Tooltip tooltip;
     Url homePage;
+    bool zeroWidth;
 
     // FOURTF: no solution yet, to be refactored later
     const QString &getCopyString() const

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -139,7 +139,7 @@ enum class MessageElementFlag : int64_t {
     OriginalLink = (1LL << 30),
 
     // ZeroWidthEmotes are emotes that are supposed to overlay over any pre-existing emotes
-    // e.g. BTTV's SoSnowy during christmas season
+    // e.g. BTTV's SoSnowy during christmas season or zerowidth 7TV emotes
     ZeroWidthEmote = (1LL << 31),
 
     // (1LL << 32) is used by SeventvEmoteImage, it is next to FfzEmote

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -66,8 +66,7 @@ namespace {
              Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")
                          .arg(name.string, (isGlobal ? "Global" : "Channel"),
                               author.string)},
-             Url{emoteLinkFormat.arg(id.string)},
-             zeroWidth});
+             Url{emoteLinkFormat.arg(id.string)}, zeroWidth});
 
         auto result = CreateEmoteResult({id, name, emote});
         return result;

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -55,8 +55,11 @@ namespace {
                                       .toObject()
                                       .value("display_name")
                                       .toString()};
-        int visibility = jsonEmote.toObject().value("visibility").toInt();
-        bool zeroWidth = (visibility & 128) == 128;
+        int64_t visibility = jsonEmote.toObject().value("visibility").toInt();
+        auto visibilityFlags =
+            SeventvEmoteVisibilityFlags(SeventvEmoteVisibilityFlag(visibility));
+        bool zeroWidth =
+            visibilityFlags.has(SeventvEmoteVisibilityFlag::ZeroWidth);
 
         auto emote = Emote(
             {name,

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -55,6 +55,8 @@ namespace {
                                       .toObject()
                                       .value("display_name")
                                       .toString()};
+        int visibility = jsonEmote.toObject().value("visibility").toInt();
+        bool zeroWidth = (visibility & 128) == 128;
 
         auto emote = Emote(
             {name,
@@ -64,7 +66,8 @@ namespace {
              Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")
                          .arg(name.string, (isGlobal ? "Global" : "Channel"),
                               author.string)},
-             Url{emoteLinkFormat.arg(id.string)}});
+             Url{emoteLinkFormat.arg(id.string)},
+             zeroWidth});
 
         auto result = CreateEmoteResult({id, name, emote});
         return result;

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -9,6 +9,27 @@
 
 namespace chatterino {
 
+// https://github.com/SevenTV/ServerGo/blob/dfe867f991e8cfd7a79d93b9bec681216c32abdb/src/mongo/datastructure/datastructure.go#L56-L67
+enum class SeventvEmoteVisibilityFlag : int64_t {
+    None = 0LL,
+
+    Private = (1LL << 0),
+    Global = (1LL << 1),
+    Unlisted = (1LL << 2),
+
+    OverrideBttv = (1LL << 3),
+    OverrideFfz = (1LL << 4),
+    OverrideTwitchGlobal = (1LL << 5),
+    OverrideTwitchSubscriber = (1LL << 6),
+
+    ZeroWidth = (1LL << 7),
+
+    All = Private | Global | Unlisted | OverrideBttv | OverrideFfz |
+          OverrideTwitchGlobal | OverrideTwitchSubscriber | ZeroWidth,
+};
+
+using SeventvEmoteVisibilityFlags = FlagsEnum<SeventvEmoteVisibilityFlag>;
+
 struct Emote;
 using EmotePtr = std::shared_ptr<const Emote>;
 class EmoteMap;

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -23,9 +23,6 @@ enum class SeventvEmoteVisibilityFlag : int64_t {
     OverrideTwitchSubscriber = (1LL << 6),
 
     ZeroWidth = (1LL << 7),
-
-    All = Private | Global | Unlisted | OverrideBttv | OverrideFfz |
-          OverrideTwitchGlobal | OverrideTwitchSubscriber | ZeroWidth,
 };
 
 using SeventvEmoteVisibilityFlags = FlagsEnum<SeventvEmoteVisibilityFlag>;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1011,7 +1011,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
              (emote = this->twitchChannel->seventvEmote(name)))
     {
         flags = MessageElementFlag::SeventvEmote;
-        if (emote.value()->zeroWidth) {
+        if (emote.value()->zeroWidth)
+        {
             flags.set(MessageElementFlag::ZeroWidthEmote);
         }
     }
@@ -1023,7 +1024,8 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
     else if ((emote = globalSeventvEmotes.emote(name)))
     {
         flags = MessageElementFlag::SeventvEmote;
-        if (emote.value()->zeroWidth) {
+        if (emote.value()->zeroWidth)
+        {
             flags.set(MessageElementFlag::ZeroWidthEmote);
         }
     }

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -1011,6 +1011,9 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
              (emote = this->twitchChannel->seventvEmote(name)))
     {
         flags = MessageElementFlag::SeventvEmote;
+        if (emote.value()->zeroWidth) {
+            flags.set(MessageElementFlag::ZeroWidthEmote);
+        }
     }
     else if (this->twitchChannel &&
              (emote = this->twitchChannel->bttvEmote(name)))
@@ -1020,6 +1023,9 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
     else if ((emote = globalSeventvEmotes.emote(name)))
     {
         flags = MessageElementFlag::SeventvEmote;
+        if (emote.value()->zeroWidth) {
+            flags.set(MessageElementFlag::ZeroWidthEmote);
+        }
     }
     else if ((emote = globalFfzEmotes.emote(name)))
     {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable
- [x] Add a proper enum with 7TV visibility flags

# Description

Adding the zero-width flag to emotes with `1 << 7` in the visibility bitfield