### PR TITLE
Fixed emote search for 7TV emotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Minor: Added autocompletion for default Twitch commands starting with the dot (e.g. `.mods` which does the same as `/mods`). (#3144)
 - Minor: Sorted usernames in `Users joined/parted` messages alphabetically. (#3421)
 - Minor: Mod list, VIP list, and Users joined/parted messages are now searchable. (#3426)
-- Minor: Add search to emote popup. (#3404)
+- Minor: Add search to emote popup. (Chatterino2#3404, Chatterino7#64)
 - Minor: Messages can now be highlighted by subscriber or founder badges. (#3445)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@
 - Minor: Added autocompletion for default Twitch commands starting with the dot (e.g. `.mods` which does the same as `/mods`). (#3144)
 - Minor: Sorted usernames in `Users joined/parted` messages alphabetically. (#3421)
 - Minor: Mod list, VIP list, and Users joined/parted messages are now searchable. (#3426)
-- Minor: Add search to emote popup. (Chatterino2#3404, Chatterino7#64)
+- Minor: Add search to emote popup. (#3404)
 - Minor: Messages can now be highlighted by subscriber or founder badges. (#3445)
 - Bugfix: Fix Split Input hotkeys not being available when input is hidden (#3362)
 - Bugfix: Fixed colored usernames sometimes not working. (#3170)

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -418,10 +418,14 @@ void EmotePopup::filterEmotes(const QString &searchText)
             twitchGlobalEmotes.push_back(setCopy);
     }
 
+    auto seventvGlobalEmotes = this->filterEmoteMap(
+        searchText, getApp()->twitch2->getSeventvEmotes().emotes());
     auto bttvGlobalEmotes = this->filterEmoteMap(
         searchText, getApp()->twitch2->getBttvEmotes().emotes());
     auto ffzGlobalEmotes = this->filterEmoteMap(
         searchText, getApp()->twitch2->getFfzEmotes().emotes());
+    auto seventvChannelEmotes =
+        this->filterEmoteMap(searchText, this->twitchChannel_->seventvEmotes());
     auto bttvChannelEmotes =
         this->filterEmoteMap(searchText, this->twitchChannel_->bttvEmotes());
     auto ffzChannelEmotes =
@@ -444,6 +448,9 @@ void EmotePopup::filterEmotes(const QString &searchText)
                  this->channel_->getName());
 
     // global
+    if (seventvGlobalEmotes->size() > 0)
+        addEmotes(*searchChannel, *seventvGlobalEmotes, "SevenTV (Global)",
+                  MessageElementFlag::SeventvEmote);
     if (bttvGlobalEmotes->size() > 0)
         addEmotes(*searchChannel, *bttvGlobalEmotes, "BetterTTV (Global)",
                   MessageElementFlag::BttvEmote);
@@ -452,6 +459,9 @@ void EmotePopup::filterEmotes(const QString &searchText)
                   MessageElementFlag::FfzEmote);
 
     // channel
+    if (seventvChannelEmotes->size() > 0)
+        addEmotes(*searchChannel, *seventvChannelEmotes, "SevenTV (Channel)",
+                  MessageElementFlag::SeventvEmote);
     if (bttvChannelEmotes->size() > 0)
         addEmotes(*searchChannel, *bttvChannelEmotes, "BetterTTV (Channel)",
                   MessageElementFlag::BttvEmote);


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

Adds 7tv emotes to the search box in the emote popup. Closes #63 
