### PR TITLE
Bug: Fixed "twitch2" typo in src/common/CompletionModel.cpp

### DIFF
--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -142,7 +142,7 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
     }
 
     // 7TV Global
-    for (auto &emote : *getApp()->twitch2->getSeventvEmotes().emotes())
+    for (auto &emote : *getApp()->twitch->getSeventvEmotes().emotes())
     {
         addString(emote.first.string, TaggedString::Type::SEVENTVGlobalEmote);
     }


### PR DESCRIPTION
# Description

I think the upstream branch Chatterino/chatterino2 changed the BTTV and FFZ emote fetching from `twitch2` to `twitch` in 58a0f43 . But the chatterino7 version still uses twitch2 to fetch SevenTV emotes.

```cpp
*getApp()->twitch2->getSeventvEmotes().emotes()
```
This failed the build from AUR.
![Screenshot from 2022-03-21 18-27-09](https://user-images.githubusercontent.com/56719270/159260748-bc9c3979-eb48-4bc2-a355-eab0e560d04b.png)
