### PR TITLE
Fixed crash related with 7TV animated pfp

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1007,8 +1007,7 @@ void UserInfoPopup::fetchSevenTVAvatar(const HelixUser &user)
 
                         this->saveCacheAvatar(data, filename);
 
-                        bool hasFocus = (QApplication::focusWidget() == nullptr);
-                        if (hasFocus)
+                        if (this->ui_.avatarButton != nullptr)
                         {
                             this->avatarUrl_ = URI;
                             this->setSevenTVAvatar(filename);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -992,7 +992,6 @@ void UserInfoPopup::fetchSevenTVAvatar(const HelixUser &user)
             if (profile_picture_id.length() > 0)
             {
                 auto URI = SEVENTV_CDR_PP.arg(id, profile_picture_id);
-                this->avatarUrl_ = URI;
 
                 NetworkRequest(URI)
                     .timeout(20000)
@@ -1007,7 +1006,13 @@ void UserInfoPopup::fetchSevenTVAvatar(const HelixUser &user)
                             this->getFilename(hash.result().toHex());
 
                         this->saveCacheAvatar(data, filename);
-                        this->setSevenTVAvatar(filename);
+
+                        bool hasFocus = (QApplication::focusWidget() == nullptr);
+                        if (hasFocus)
+                        {
+                            this->avatarUrl_ = URI;
+                            this->setSevenTVAvatar(filename);
+                        }
 
                         return Success;
                     })


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR fixes a crash that occurs when you open someone's usercard and close it before the 7TV pfp is loaded. Closes #84  