### PR TITLE
fix: correctly clean up memory after applying drop shadows to paints

### DIFF
--- a/src/providers/seventv/paints/Paint.cpp
+++ b/src/providers/seventv/paints/Paint.cpp
@@ -50,11 +50,15 @@ QPixmap Paint::getPixmap(const QString text, const QFont font,
         auto scaledShadow = shadow.scaled(scale);
 
         // HACK: create a QLabel from the pixmap to apply drop shadows
-        QLabel *label = new QLabel();
-        label->setPixmap(pixmap);
-        label->setGraphicsEffect(scaledShadow.getGraphicsEffect());
+        QLabel label;
+        label.setPixmap(pixmap);
 
-        pixmap = label->grab();
+        auto dropShadow = scaledShadow.getGraphicsEffect();
+        label.setGraphicsEffect(dropShadow);
+
+        pixmap = label.grab();
+
+        delete dropShadow;
     }
 
     if (drawColon)


### PR DESCRIPTION
# Description

Found another leak, sorry for the 2 dumb mistakes. Memory management is an area where I still have to learn a lot more, I hope this doesn't cause too many inconveniences for the people that downloaded the first nightly build :/

Not even sure why I used a pointer for the QLabel in that place...

I did some more testing and couldn't see any abnormal memory usage or other areas in the code that would cause anything though, so I think we're good now.