### PR TITLE
fix: correctly scale paints with drop shadows on high DPI displays

### DIFF
--- a/src/providers/seventv/paints/Paint.cpp
+++ b/src/providers/seventv/paints/Paint.cpp
@@ -47,14 +47,19 @@ QPixmap Paint::getPixmap(const QString text, const QFont font,
         if (!shadow.isValid())
             continue;
 
-        auto scaledShadow = shadow.scaled(scale);
-
         // HACK: create a QLabel from the pixmap to apply drop shadows
         QLabel *label = new QLabel();
+
+        auto scaledShadow = shadow.scaled(scale / label->devicePixelRatioF());
+
+        // NOTE: avoid scaling issues on high DPI displays
+        pixmap.setDevicePixelRatio(label->devicePixelRatioF());
+
         label->setPixmap(pixmap);
         label->setGraphicsEffect(scaledShadow.getGraphicsEffect());
 
         pixmap = label->grab();
+        pixmap.setDevicePixelRatio(1);
     }
 
     if (drawColon)


### PR DESCRIPTION
# Description

Fixes the scaling issues on high-DPI retina displays.

![image](https://user-images.githubusercontent.com/80157503/176480361-f6adbf13-8701-4b5d-8f9a-29e2cf41cdc6.png)

Fixes #107