### PR TITLE
fix(eventapi): only remove emotes with the same id

### DIFF
--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -322,6 +322,8 @@ bool SeventvEmotes::removeEmote(Atomic<std::shared_ptr<const EmoteMap>> &map,
 {
     EmoteMap updatedMap = *map.get();
     auto it = updatedMap.find(EmoteName{emoteName});
+
+    // Emotes don't store their id, but the emote url always ends with the emote id.
     if (it == updatedMap.end() ||
         !it->second->homePage.string.endsWith(emoteId))
     {

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -326,7 +326,7 @@ bool SeventvEmotes::removeEmote(Atomic<std::shared_ptr<const EmoteMap>> &map,
         !it->second->homePage.string.endsWith(emoteId))
     {
         // We already copied the map at this point and are now discarding the copy.
-        // This is fine, because these case should be really rare.
+        // This is fine, because these cases should be really rare.
         return false;
     }
     updatedMap.erase(it);

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -317,14 +317,16 @@ boost::optional<EmotePtr> SeventvEmotes::updateEmote(
 }
 
 bool SeventvEmotes::removeEmote(Atomic<std::shared_ptr<const EmoteMap>> &map,
-                                const QString &emoteName)
+                                const QString &emoteName,
+                                const QString &emoteId)
 {
     EmoteMap updatedMap = *map.get();
     auto it = updatedMap.find(EmoteName{emoteName});
-    if (it == updatedMap.end())
+    if (it == updatedMap.end() ||
+        !it->second->homePage.string.endsWith(emoteId))
     {
         // We already copied the map at this point and are now discarding the copy.
-        // This is fine, because this case should be really rare.
+        // This is fine, because these case should be really rare.
         return false;
     }
     updatedMap.erase(it);

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -48,7 +48,7 @@ public:
         Atomic<std::shared_ptr<const EmoteMap>> &map, QString *emoteBaseName,
         const QJsonValue &emoteJson);
     static bool removeEmote(Atomic<std::shared_ptr<const EmoteMap>> &map,
-                            const QString &emoteName);
+                            const QString &emoteName, const QString &emoteId);
     static void loadChannel(std::weak_ptr<Channel> channel,
                             const QString &channelId,
                             std::function<void(EmoteMap &&)> callback,

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -616,7 +616,8 @@ void TwitchChannel::updateSeventvEmote(const EventApiEmoteUpdate &action)
 
 void TwitchChannel::removeSeventvEmote(const EventApiEmoteUpdate &action)
 {
-    if (SeventvEmotes::removeEmote(this->seventvEmotes_, action.emoteName))
+    if (SeventvEmotes::removeEmote(this->seventvEmotes_, action.emoteName,
+                                   action.emoteId))
     {
         this->addOrReplaceSevenTvEventAddRemove(
             MessageBuilder(seventvRemoveEmoteMessage, action.actor,


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description

This PR fixes the following scenario:

* Emote 1 with name `foo` is added (typing `foo` shows emote 1)
* Emote 2 with name `foo` is added (typing `foo` shows emote 2)
* Emote 1 is removed (typing `foo` wouldn't show any emote; now shows emote 2)

This PR _doesn't_ fix the following scenario:

* Emote 1 with name `foo` is added (typing `foo` shows emote 1)
* Emote 2 with name `foo` is added (typing `foo` shows emote 2)
* Emote _2_ is removed (typing `foo` won't show any emote)

This can't be fixed, because by adding emote 2, we overwrite emote 1 (emotes are stored in {name => emote}), so there's a single entry for `foo`.