### PR TITLE
Update SevenTV badge setting to be inline with other 7TV settings

### DIFF
--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -622,7 +622,7 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Subscriber ", s.showBadgesSubscription);
     layout.addCheckbox("Vanity (prime, bits, subgifter)", s.showBadgesVanity);
     layout.addCheckbox("Chatterino", s.showBadgesChatterino);
-    layout.addCheckbox("SevenTV", s.showBadgesSeventv);
+    layout.addCheckbox("7TV", s.showBadgesSeventv);
     layout.addCheckbox("FrankerFaceZ (Bot, FFZ Supporter, FFZ Developer)",
                        s.showBadgesFfz);
     layout.addSeperator();


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description
Changes badge toggle setting from `SevenTV` to `7TV` as all other mentions of 7TV are handled this way

`[2022-08-15 11:44:22] #pajlada occluder: dankCrayon why are the 7tv badges in settings referred to as "SevenTV" but with everything else it's "7tv"`
