### PR TITLE
Fix SevenTV Global emotes not loading & SevenTV emote loading setting

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -201,6 +201,12 @@ int Application::run(QApplication &qtApp)
     getSettings()->enableFFZChannelEmotes.connect([this] {
         this->twitch->reloadAllFFZChannelEmotes();
     });
+    getSettings()->enableSevenTVGlobalEmotes.connect([this] {
+        this->twitch->reloadSevenTVGlobalEmotes();
+    });
+    getSettings()->enableSevenTVChannelEmotes.connect([this] {
+        this->twitch->reloadAllSevenTVChannelEmotes();
+    });
 
     return qtApp.exec();
 }

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -208,6 +208,12 @@ void TwitchChannel::setLocalizedName(const QString &name)
 
 void TwitchChannel::refreshSevenTVChannelEmotes(bool manualRefresh)
 {
+    if (!Settings::instance().enableSevenTVChannelEmotes)
+    {
+        this->seventvEmotes_.set(EMPTY_EMOTE_MAP);
+        return;
+    }
+
     SeventvEmotes::loadChannel(
         weakOf<Channel>(this), this->roomId(),
         [this, weak = weakOf<Channel>(this)](auto &&emoteMap) {

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -514,7 +514,7 @@ void TwitchIrcServer::reloadAllFFZChannelEmotes()
 
 void TwitchIrcServer::reloadSevenTVGlobalEmotes()
 {
-    this->ffz.loadEmotes();
+    this->seventv.loadEmotes();
 }
 
 void TwitchIrcServer::reloadAllSevenTVChannelEmotes()

--- a/src/providers/twitch/TwitchIrcServer.cpp
+++ b/src/providers/twitch/TwitchIrcServer.cpp
@@ -450,11 +450,6 @@ void TwitchIrcServer::onMessageSendRequested(TwitchChannel *channel,
     sent = true;
 }
 
-const SeventvEmotes &TwitchIrcServer::getSeventvEmotes() const
-{
-    return this->seventv;
-}
-
 void TwitchIrcServer::onReplySendRequested(TwitchChannel *channel,
                                            const QString &message,
                                            const QString &replyId, bool &sent)
@@ -480,6 +475,10 @@ const BttvEmotes &TwitchIrcServer::getBttvEmotes() const
 const FfzEmotes &TwitchIrcServer::getFfzEmotes() const
 {
     return this->ffz;
+}
+const SeventvEmotes &TwitchIrcServer::getSeventvEmotes() const
+{
+    return this->seventv;
 }
 
 void TwitchIrcServer::reloadBTTVGlobalEmotes()


### PR DESCRIPTION
Pull request checklist:

- [X] `CHANGELOG.md` was updated, if applicable

# Description

- Fixed copy/paste error preventing SevenTV global emotes from loading
- Added missing code for the setting to disable SevenTV emotes

~~TODO: Figure out what's causing the FFZ channel emote error~~
Either an issue on FFZ's side, or a race condition causing FFZ requests to send before channelID can be found, either way not a chatterino7 issue

Fixes #133 