### PR TITLE
added button to open 7tv user page

### DIFF
--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -8,6 +8,7 @@
 #include <pajlada/signals/scoped-connection.hpp>
 #include <pajlada/signals/signal.hpp>
 #include <QMovie>
+#include <widgets/helper/EffectLabel.hpp>
 
 #include <chrono>
 
@@ -46,6 +47,7 @@ private:
 
     void loadAvatar(const HelixUser &user);
 
+    void loadSevenTVUser(const HelixUser &user);
     void loadSevenTVAvatar(const HelixUser &user);
     void setSevenTVAvatar(const QString &filename);
 
@@ -61,6 +63,7 @@ private:
     QString userName_;
     QString userId_;
     QString avatarUrl_;
+    QString stvUserId_ = "";
 
     // The channel the popup was opened from (e.g. /mentions or #forsen). Can be a special channel.
     ChannelPtr channel_;
@@ -96,6 +99,8 @@ private:
 
         Label *noMessagesLabel = nullptr;
         ChannelView *latestMessages = nullptr;
+
+        EffectLabel2 *stvUser = nullptr;
     } ui_;
 
     class TimeoutWidget : public BaseWidget


### PR DESCRIPTION
Pull request checklist:

- [ ] `CHANGELOG.md` was updated, if applicable

# Description
Added button on usercard to open 7tv user page. If user does not have a 7tv account, the button is removed.

It's just annoying to always have to open https://7tv.app/ -> search for user -> click on user.

Not sure if this is something that can be added upstream or not,

<!-- If applicable, please include a summary of what you've changed and what issue is fixed. In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested -->

### User with 7tv account:
![image](https://user-images.githubusercontent.com/109011672/209918817-16db0776-b321-4d7a-859b-e403abf684b7.png)

### User without 7tv account:
![image](https://user-images.githubusercontent.com/109011672/209918898-63586901-4003-4aba-adbf-3b9a1d6a2e43.png)

Also I'm not sure if the submodules diff is important or not, never touched them, not sure why they show up in the commit.
