### PR TITLE
Implement Personal Emotes

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -697,6 +697,19 @@ void Application::initSeventvEventAPI()
                                                  chan.updateSeventvUser(data);
                                              });
         });
+    this->twitch->seventvEventAPI->signals_.personalEmoteSetAdded.connect(
+        [&](const auto &data) {
+            postToThread([this, data]() {
+                this->twitch->forEachChannelAndSpecialChannels([=](auto chan) {
+                    if (auto *twitchChannel =
+                            dynamic_cast<TwitchChannel *>(chan.get()))
+                    {
+                        twitchChannel->upsertPersonalSeventvEmotes(data.first,
+                                                                   data.second);
+                    }
+                });
+            });
+        });
 
     this->twitch->seventvEventAPI->start();
 }

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -24,6 +24,7 @@
 #include "providers/seventv/SeventvBadges.hpp"
 #include "providers/seventv/SeventvEventAPI.hpp"
 #include "providers/seventv/SeventvPaints.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/PubSubActions.hpp"
 #include "providers/twitch/PubSubManager.hpp"
@@ -85,6 +86,7 @@ Application::Application(Settings &_settings, Paths &_paths)
     , ffzBadges(&this->emplace<FfzBadges>())
     , seventvBadges(&this->emplace<SeventvBadges>())
     , seventvPaints(&this->emplace<SeventvPaints>())
+    , seventvPersonalEmotes(&this->emplace<SeventvPersonalEmotes>())
     , userData(&this->emplace<UserDataController>())
     , sound(&this->emplace<SoundController>())
     , logging(&this->emplace<Logging>())
@@ -639,30 +641,54 @@ void Application::initSeventvEventAPI()
 
     this->twitch->seventvEventAPI->signals_.emoteAdded.connect(
         [&](const auto &data) {
-            postToThread([this, data] {
-                this->twitch->forEachSeventvEmoteSet(
-                    data.emoteSetID, [data](TwitchChannel &chan) {
-                        chan.addSeventvEmote(data);
-                    });
-            });
+            if (this->seventvPersonalEmotes->hasEmoteSet(data.emoteSetID))
+            {
+                this->seventvPersonalEmotes->updateEmoteSet(data.emoteSetID,
+                                                            data);
+            }
+            else
+            {
+                postToThread([this, data] {
+                    this->twitch->forEachSeventvEmoteSet(
+                        data.emoteSetID, [data](TwitchChannel &chan) {
+                            chan.addSeventvEmote(data);
+                        });
+                });
+            }
         });
     this->twitch->seventvEventAPI->signals_.emoteUpdated.connect(
         [&](const auto &data) {
-            postToThread([this, data] {
-                this->twitch->forEachSeventvEmoteSet(
-                    data.emoteSetID, [data](TwitchChannel &chan) {
-                        chan.updateSeventvEmote(data);
-                    });
-            });
+            if (this->seventvPersonalEmotes->hasEmoteSet(data.emoteSetID))
+            {
+                this->seventvPersonalEmotes->updateEmoteSet(data.emoteSetID,
+                                                            data);
+            }
+            else
+            {
+                postToThread([this, data] {
+                    this->twitch->forEachSeventvEmoteSet(
+                        data.emoteSetID, [data](TwitchChannel &chan) {
+                            chan.updateSeventvEmote(data);
+                        });
+                });
+            }
         });
     this->twitch->seventvEventAPI->signals_.emoteRemoved.connect(
         [&](const auto &data) {
-            postToThread([this, data] {
-                this->twitch->forEachSeventvEmoteSet(
-                    data.emoteSetID, [data](TwitchChannel &chan) {
-                        chan.removeSeventvEmote(data);
-                    });
-            });
+            if (this->seventvPersonalEmotes->hasEmoteSet(data.emoteSetID))
+            {
+                this->seventvPersonalEmotes->updateEmoteSet(data.emoteSetID,
+                                                            data);
+            }
+            else
+            {
+                postToThread([this, data] {
+                    this->twitch->forEachSeventvEmoteSet(
+                        data.emoteSetID, [data](TwitchChannel &chan) {
+                            chan.removeSeventvEmote(data);
+                        });
+                });
+            }
         });
     this->twitch->seventvEventAPI->signals_.userUpdated.connect(
         [&](const auto &data) {

--- a/src/Application.hpp
+++ b/src/Application.hpp
@@ -35,6 +35,7 @@ class SeventvBadges;
 class SeventvPaints;
 class FfzBadges;
 class SeventvBadges;
+class SeventvPersonalEmotes;
 
 class IApplication
 {
@@ -95,6 +96,7 @@ public:
     FfzBadges *const ffzBadges{};
     SeventvBadges *const seventvBadges{};
     SeventvPaints *const seventvPaints{};
+    SeventvPersonalEmotes *const seventvPersonalEmotes{};
     UserDataController *const userData{};
     SoundController *const sound{};
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -273,6 +273,8 @@ set(SOURCE_FILES
         providers/seventv/SeventvEmotes.hpp
         providers/seventv/SeventvEventAPI.cpp
         providers/seventv/SeventvEventAPI.hpp
+        providers/seventv/SeventvPersonalEmotes.cpp
+        providers/seventv/SeventvPersonalEmotes.hpp
 
         providers/seventv/eventapi/Client.cpp
         providers/seventv/eventapi/Client.hpp

--- a/src/common/CompletionModel.cpp
+++ b/src/common/CompletionModel.cpp
@@ -6,6 +6,7 @@
 #include "controllers/commands/Command.hpp"
 #include "controllers/commands/CommandController.hpp"
 #include "messages/Emote.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchCommon.hpp"
@@ -211,6 +212,17 @@ void CompletionModel::refresh(const QString &prefix, bool isFirstWord)
             addString(formatUserMention(name, isFirstWord,
                                         getSettings()->mentionUsersWithComma),
                       TaggedString::Type::Username);
+        }
+    }
+
+    // 7TV Personal
+    if (const auto map = getApp()->seventvPersonalEmotes->getEmoteSetForUser(
+            getApp()->accounts->twitch.getCurrent()->getUserId()))
+    {
+        for (const auto &emote : *map.get())
+        {
+            addString(emote.first.string,
+                      TaggedString::Type::SeventvPersonalEmote);
         }
     }
 

--- a/src/common/CompletionModel.hpp
+++ b/src/common/CompletionModel.hpp
@@ -24,6 +24,7 @@ class CompletionModel : public QAbstractListModel
             BTTVChannelEmote,
             SeventvGlobalEmote,
             SeventvChannelEmote,
+            SeventvPersonalEmote,
             TwitchGlobalEmote,
             TwitchLocalEmote,
             TwitchSubscriberEmote,

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -68,31 +68,31 @@ SBHighlight Message::getScrollBarHighlight() const
 std::shared_ptr<const Message> Message::cloneWith(
     const std::function<void(Message &)> &fn) const
 {
-    Message cloned;
-    cloned.flags = this->flags;
-    cloned.parseTime = this->parseTime;
-    cloned.id = this->id;
-    cloned.searchText = this->searchText;
-    cloned.messageText = this->messageText;
-    cloned.loginName = this->loginName;
-    cloned.displayName = this->displayName;
-    cloned.localizedName = this->localizedName;
-    cloned.timeoutUser = this->timeoutUser;
-    cloned.channelName = this->channelName;
-    cloned.usernameColor = this->usernameColor;
-    cloned.serverReceivedTime = this->serverReceivedTime;
-    cloned.badges = this->badges;
-    cloned.badgeInfos = this->badgeInfos;
-    cloned.highlightColor = this->highlightColor;
-    cloned.replyThread = this->replyThread;
-    cloned.count = this->count;
+    auto cloned = std::make_shared<Message>();
+    cloned->flags = this->flags;
+    cloned->parseTime = this->parseTime;
+    cloned->id = this->id;
+    cloned->searchText = this->searchText;
+    cloned->messageText = this->messageText;
+    cloned->loginName = this->loginName;
+    cloned->displayName = this->displayName;
+    cloned->localizedName = this->localizedName;
+    cloned->timeoutUser = this->timeoutUser;
+    cloned->channelName = this->channelName;
+    cloned->usernameColor = this->usernameColor;
+    cloned->serverReceivedTime = this->serverReceivedTime;
+    cloned->badges = this->badges;
+    cloned->badgeInfos = this->badgeInfos;
+    cloned->highlightColor = this->highlightColor;
+    cloned->replyThread = this->replyThread;
+    cloned->count = this->count;
     std::transform(this->elements.cbegin(), this->elements.cend(),
-                   std::back_inserter(cloned.elements),
+                   std::back_inserter(cloned->elements),
                    [](const auto &element) {
                        return element->clone();
                    });
-    fn(cloned);
-    return std::make_shared<Message>(cloned);
+    fn(*cloned);
+    return std::move(cloned);
 }
 
 // Static

--- a/src/messages/Message.cpp
+++ b/src/messages/Message.cpp
@@ -11,6 +11,9 @@
 #include "util/IrcHelpers.hpp"
 #include "widgets/helper/ScrollbarHighlight.hpp"
 
+#include <algorithm>
+#include <iterator>
+
 using SBHighlight = chatterino::ScrollbarHighlight;
 
 namespace chatterino {
@@ -60,6 +63,36 @@ SBHighlight Message::getScrollBarHighlight() const
     }
 
     return SBHighlight();
+}
+
+std::shared_ptr<const Message> Message::cloneWith(
+    const std::function<void(Message &)> &fn) const
+{
+    Message cloned;
+    cloned.flags = this->flags;
+    cloned.parseTime = this->parseTime;
+    cloned.id = this->id;
+    cloned.searchText = this->searchText;
+    cloned.messageText = this->messageText;
+    cloned.loginName = this->loginName;
+    cloned.displayName = this->displayName;
+    cloned.localizedName = this->localizedName;
+    cloned.timeoutUser = this->timeoutUser;
+    cloned.channelName = this->channelName;
+    cloned.usernameColor = this->usernameColor;
+    cloned.serverReceivedTime = this->serverReceivedTime;
+    cloned.badges = this->badges;
+    cloned.badgeInfos = this->badgeInfos;
+    cloned.highlightColor = this->highlightColor;
+    cloned.replyThread = this->replyThread;
+    cloned.count = this->count;
+    std::transform(this->elements.cbegin(), this->elements.cend(),
+                   std::back_inserter(cloned.elements),
+                   [](const auto &element) {
+                       return element->clone();
+                   });
+    fn(cloned);
+    return std::make_shared<Message>(cloned);
 }
 
 // Static

--- a/src/messages/Message.hpp
+++ b/src/messages/Message.hpp
@@ -8,6 +8,7 @@
 #include <QTime>
 
 #include <cinttypes>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -88,6 +89,15 @@ struct Message : boost::noncopyable {
     std::vector<QString> seventvEventTargetEmotes;
 
     ScrollbarHighlight getScrollBarHighlight() const;
+
+    /**
+     * Clones this message. Before contructing the shared pointer, 
+     * `fn` is called with a reference to the new message.
+     *
+     * @return An identical message, independent from this one.
+     */
+    std::shared_ptr<const Message> cloneWith(
+        const std::function<void(Message &)> &fn) const;
 };
 
 using MessagePtr = std::shared_ptr<const Message>;

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -13,6 +13,8 @@
 #include "singletons/Theme.hpp"
 #include "util/DebugCount.hpp"
 
+#include <memory>
+
 namespace chatterino {
 
 MessageElement::MessageElement(MessageElementFlags flags)
@@ -98,6 +100,16 @@ MessageElement *MessageElement::updateLink()
     return this;
 }
 
+void MessageElement::cloneFrom(const MessageElement &source)
+{
+    this->text_ = source.text_;
+    this->link_ = source.link_;
+    this->tooltip_ = source.tooltip_;
+    this->thumbnail_ = source.thumbnail_;
+    this->thumbnailType_ = source.thumbnailType_;
+    this->flags_ = source.flags_;
+}
+
 // Empty
 EmptyElement::EmptyElement()
     : MessageElement(MessageElementFlag::None)
@@ -107,6 +119,13 @@ EmptyElement::EmptyElement()
 void EmptyElement::addToContainer(MessageLayoutContainer &container,
                                   MessageElementFlags flags)
 {
+}
+
+std::unique_ptr<MessageElement> EmptyElement::clone() const
+{
+    auto el = std::make_unique<EmptyElement>();
+    el->cloneFrom(*this);
+    return el;
 }
 
 EmptyElement &EmptyElement::instance()
@@ -136,6 +155,13 @@ void ImageElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> ImageElement::clone() const
+{
+    auto el = std::make_unique<ImageElement>(this->image_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 CircularImageElement::CircularImageElement(ImagePtr image, int padding,
                                            QColor background,
                                            MessageElementFlags flags)
@@ -159,6 +185,14 @@ void CircularImageElement::addToContainer(MessageLayoutContainer &container,
                                   this->background_, this->padding_))
                                  ->setLink(this->getLink()));
     }
+}
+
+std::unique_ptr<MessageElement> CircularImageElement::clone() const
+{
+    auto el = std::make_unique<CircularImageElement>(
+        this->image_, this->padding_, this->background_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
 }
 
 // EMOTE
@@ -216,6 +250,15 @@ MessageLayoutElement *EmoteElement::makeImageLayoutElement(
     return new ImageLayoutElement(*this, image, size);
 }
 
+std::unique_ptr<MessageElement> EmoteElement::clone() const
+{
+    auto el = std::make_unique<EmoteElement>(this->emote_, this->getFlags());
+    el->textElement_ = std::unique_ptr<TextElement>(
+        dynamic_cast<TextElement *>(this->textElement_->clone().release()));
+    el->cloneFrom(*this);
+    return el;
+}
+
 // BADGE
 BadgeElement::BadgeElement(const EmotePtr &emote, MessageElementFlags flags)
     : MessageElement(flags)
@@ -255,6 +298,13 @@ MessageLayoutElement *BadgeElement::makeImageLayoutElement(
     return element;
 }
 
+std::unique_ptr<MessageElement> BadgeElement::clone() const
+{
+    auto el = std::make_unique<BadgeElement>(this->emote_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 // MOD BADGE
 ModBadgeElement::ModBadgeElement(const EmotePtr &data,
                                  MessageElementFlags flags_)
@@ -274,6 +324,13 @@ MessageLayoutElement *ModBadgeElement::makeImageLayoutElement(
     return element;
 }
 
+std::unique_ptr<MessageElement> ModBadgeElement::clone() const
+{
+    auto el = std::make_unique<ModBadgeElement>(this->emote_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 // VIP BADGE
 VipBadgeElement::VipBadgeElement(const EmotePtr &data,
                                  MessageElementFlags flags_)
@@ -288,6 +345,13 @@ MessageLayoutElement *VipBadgeElement::makeImageLayoutElement(
         (new ImageLayoutElement(*this, image, size))->setLink(this->getLink());
 
     return element;
+}
+
+std::unique_ptr<MessageElement> VipBadgeElement::clone() const
+{
+    auto el = std::make_unique<VipBadgeElement>(this->emote_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
 }
 
 // FFZ Badge
@@ -306,6 +370,14 @@ MessageLayoutElement *FfzBadgeElement::makeImageLayoutElement(
             ->setLink(this->getLink());
 
     return element;
+}
+
+std::unique_ptr<MessageElement> FfzBadgeElement::clone() const
+{
+    auto el = std::make_unique<FfzBadgeElement>(this->emote_, this->getFlags(),
+                                                this->color);
+    el->cloneFrom(*this);
+    return el;
 }
 
 // TEXT
@@ -422,6 +494,15 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
                 text.mid(wordStart), width, this->hasTrailingSpace()));
         }
     }
+}
+
+std::unique_ptr<MessageElement> TextElement::clone() const
+{
+    auto el = std::make_unique<TextElement>(QString(), this->getFlags(),
+                                            this->color_, this->style_);
+    el->words_ = this->words_;
+    el->cloneFrom(*this);
+    return el;
 }
 
 SingleLineTextElement::SingleLineTextElement(const QString &text,
@@ -572,6 +653,15 @@ void SingleLineTextElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> SingleLineTextElement::clone() const
+{
+    auto el = std::make_unique<SingleLineTextElement>(
+        QString(), this->getFlags(), this->color_, this->style_);
+    el->words_ = this->words_;
+    el->cloneFrom(*this);
+    return el;
+}
+
 // TIMESTAMP
 TimestampElement::TimestampElement(QTime time)
     : MessageElement(MessageElementFlag::Timestamp)
@@ -604,6 +694,13 @@ TextElement *TimestampElement::formatTime(const QTime &time)
 
     return new TextElement(format, MessageElementFlag::Timestamp,
                            MessageColor::System, FontStyle::ChatMedium);
+}
+
+std::unique_ptr<MessageElement> TimestampElement::clone() const
+{
+    auto el = std::make_unique<TimestampElement>(this->time_);
+    el->cloneFrom(*this);
+    return el;
 }
 
 // TWITCH MODERATION
@@ -640,6 +737,13 @@ void TwitchModerationElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> TwitchModerationElement::clone() const
+{
+    auto el = std::make_unique<TwitchModerationElement>();
+    el->cloneFrom(*this);
+    return el;
+}
+
 LinebreakElement::LinebreakElement(MessageElementFlags flags)
     : MessageElement(flags)
 {
@@ -652,6 +756,13 @@ void LinebreakElement::addToContainer(MessageLayoutContainer &container,
     {
         container.breakLine();
     }
+}
+
+std::unique_ptr<MessageElement> LinebreakElement::clone() const
+{
+    auto el = std::make_unique<LinebreakElement>(this->getFlags());
+    el->cloneFrom(*this);
+    return el;
 }
 
 ScalingImageElement::ScalingImageElement(ImageSet images,
@@ -679,6 +790,14 @@ void ScalingImageElement::addToContainer(MessageLayoutContainer &container,
     }
 }
 
+std::unique_ptr<MessageElement> ScalingImageElement::clone() const
+{
+    auto el =
+        std::make_unique<ScalingImageElement>(this->images_, this->getFlags());
+    el->cloneFrom(*this);
+    return el;
+}
+
 ReplyCurveElement::ReplyCurveElement()
     : MessageElement(MessageElementFlag::RepliedMessage)
 {
@@ -699,6 +818,13 @@ void ReplyCurveElement::addToContainer(MessageLayoutContainer &container,
             new ReplyCurveLayoutElement(*this, width * scale, thickness * scale,
                                         radius * scale, margin * scale));
     }
+}
+
+std::unique_ptr<MessageElement> ReplyCurveElement::clone() const
+{
+    auto el = std::make_unique<ReplyCurveElement>();
+    el->cloneFrom(*this);
+    return el;
 }
 
 }  // namespace chatterino

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -79,6 +79,11 @@ const MessageElement::ThumbnailType &MessageElement::getThumbnailType() const
     return this->thumbnailType_;
 }
 
+const QString &MessageElement::getText() const
+{
+    return this->text_;
+}
+
 const Link &MessageElement::getLink() const
 {
     return this->link_;
@@ -392,6 +397,16 @@ TextElement::TextElement(const QString &text, MessageElementFlags flags,
         this->words_.push_back({word, -1});
         // fourtf: add logic to store multiple spaces after message
     }
+}
+
+MessageColor TextElement::color() const
+{
+    return this->color_;
+}
+
+FontStyle TextElement::style() const
+{
+    return this->style_;
 }
 
 void TextElement::addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -399,6 +399,15 @@ TextElement::TextElement(const QString &text, MessageElementFlags flags,
     }
 }
 
+TextElement::TextElement(std::vector<Word> &&words, MessageElementFlags flags,
+                         const MessageColor &color, FontStyle style)
+    : MessageElement(flags)
+    , color_(color)
+    , style_(style)
+    , words_(std::move(words))
+{
+}
+
 MessageColor TextElement::color() const
 {
     return this->color_;
@@ -407,6 +416,11 @@ MessageColor TextElement::color() const
 FontStyle TextElement::style() const
 {
     return this->style_;
+}
+
+const std::vector<TextElement::Word> &TextElement::words() const
+{
+    return this->words_;
 }
 
 void TextElement::addToContainer(MessageLayoutContainer &container,

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -194,11 +194,15 @@ public:
     virtual void addToContainer(MessageLayoutContainer &container,
                                 MessageElementFlags flags) = 0;
 
+    virtual std::unique_ptr<MessageElement> clone() const = 0;
+
     pajlada::Signals::NoArgSignal linkChanged;
 
 protected:
     MessageElement(MessageElementFlags flags);
     bool trailingSpace = true;
+
+    void cloneFrom(const MessageElement &source);
 
 private:
     QString text_;
@@ -218,6 +222,8 @@ public:
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
     static EmptyElement &instance();
 
 private:
@@ -233,6 +239,8 @@ public:
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 private:
     ImagePtr image_;
 };
@@ -246,6 +254,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     ImagePtr image_;
@@ -264,6 +274,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     MessageColor color_;
@@ -287,6 +299,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     MessageColor color_;
@@ -312,6 +326,8 @@ public:
                         MessageElementFlags flags_) override;
     EmotePtr getEmote() const;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                          const QSize &size);
@@ -331,11 +347,11 @@ public:
 
     EmotePtr getEmote() const;
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 protected:
     virtual MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                          const QSize &size);
-
-private:
     EmotePtr emote_;
 };
 
@@ -343,6 +359,8 @@ class ModBadgeElement : public BadgeElement
 {
 public:
     ModBadgeElement(const EmotePtr &data, MessageElementFlags flags_);
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
@@ -354,6 +372,8 @@ class VipBadgeElement : public BadgeElement
 public:
     VipBadgeElement(const EmotePtr &data, MessageElementFlags flags_);
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
                                                  const QSize &size) override;
@@ -364,6 +384,8 @@ class FfzBadgeElement : public BadgeElement
 public:
     FfzBadgeElement(const EmotePtr &data, MessageElementFlags flags_,
                     QColor color_);
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 protected:
     MessageLayoutElement *makeImageLayoutElement(const ImagePtr &image,
@@ -383,6 +405,8 @@ public:
 
     TextElement *formatTime(const QTime &time);
 
+    std::unique_ptr<MessageElement> clone() const override;
+
 private:
     QTime time_;
     std::unique_ptr<TextElement> element_;
@@ -398,6 +422,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 };
 
 // Forces a linebreak
@@ -408,6 +434,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 };
 
 // Image element which will pick the quality of the image based on ui scale
@@ -418,6 +446,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 
 private:
     ImageSet images_;
@@ -430,6 +460,8 @@ public:
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
+
+    std::unique_ptr<MessageElement> clone() const override;
 };
 
 }  // namespace chatterino

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -186,6 +186,7 @@ public:
     const ImagePtr &getThumbnail() const;
     const ThumbnailType &getThumbnailType() const;
 
+    const QString &getText() const;
     const Link &getLink() const;
     bool hasTrailingSpace() const;
     MessageElementFlags getFlags() const;
@@ -271,6 +272,9 @@ public:
                 const MessageColor &color = MessageColor::Text,
                 FontStyle style = FontStyle::ChatMedium);
     ~TextElement() override = default;
+
+    MessageColor color() const;
+    FontStyle style() const;
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;

--- a/src/messages/MessageElement.hpp
+++ b/src/messages/MessageElement.hpp
@@ -268,13 +268,23 @@ private:
 class TextElement : public MessageElement
 {
 public:
+    struct Word {
+        QString text;
+        int width = -1;
+    };
+
     TextElement(const QString &text, MessageElementFlags flags,
+                const MessageColor &color = MessageColor::Text,
+                FontStyle style = FontStyle::ChatMedium);
+    TextElement(std::vector<Word> &&words, MessageElementFlags flags,
                 const MessageColor &color = MessageColor::Text,
                 FontStyle style = FontStyle::ChatMedium);
     ~TextElement() override = default;
 
     MessageColor color() const;
     FontStyle style() const;
+
+    const std::vector<Word> &words() const;
 
     void addToContainer(MessageLayoutContainer &container,
                         MessageElementFlags flags) override;
@@ -285,10 +295,6 @@ private:
     MessageColor color_;
     FontStyle style_;
 
-    struct Word {
-        QString text;
-        int width = -1;
-    };
     std::vector<Word> words_;
 };
 

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -441,8 +441,14 @@ void SeventvEmotes::getEmoteSet(
             auto json = result.parseJson();
             auto parsedEmotes = json["emotes"].toArray();
 
-            auto emoteMap =
-                parseEmotes(parsedEmotes, SeventvEmoteSetKind::Channel);
+            auto kind = SeventvEmoteSetKind::Channel;
+            if (SeventvEmoteSetFlags(SeventvEmoteSetFlag(json["flags"].toInt()))
+                    .has(SeventvEmoteSetFlag::Personal))
+            {
+                kind = SeventvEmoteSetKind::Personal;
+            }
+
+            auto emoteMap = parseEmotes(parsedEmotes, kind);
 
             qCDebug(chatterinoSeventv) << "Loaded" << emoteMap.size()
                                        << "7TV Emotes from" << emoteSetId;

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -77,23 +77,40 @@ bool isZeroWidthRecommended(const QJsonObject &emoteData)
     return flags.has(SeventvEmoteFlag::ZeroWidth);
 }
 
-Tooltip createTooltip(const QString &name, const QString &author, bool isGlobal)
+QString kindToString(SeventvEmoteSetKind kind)
+{
+    switch (kind)
+    {
+        case SeventvEmoteSetKind::Global:
+            return QStringLiteral("Global");
+        case SeventvEmoteSetKind::Personal:
+            return QStringLiteral("Personal");
+        case SeventvEmoteSetKind::Channel:
+            return QStringLiteral("Channel");
+        default:
+            return QStringLiteral("");
+    }
+}
+
+Tooltip createTooltip(const QString &name, const QString &author,
+                      SeventvEmoteSetKind kind)
 {
     return Tooltip{QString("%1<br>%2 7TV Emote<br>By: %3")
-                       .arg(name, isGlobal ? "Global" : "Channel",
+                       .arg(name, kindToString(kind),
                             author.isEmpty() ? "<deleted>" : author)};
 }
 
 Tooltip createAliasedTooltip(const QString &name, const QString &baseName,
-                             const QString &author, bool isGlobal)
+                             const QString &author, SeventvEmoteSetKind kind)
 {
     return Tooltip{QString("%1<br>Alias of %2<br>%3 7TV Emote<br>By: %4")
-                       .arg(name, baseName, isGlobal ? "Global" : "Channel",
+                       .arg(name, baseName, kindToString(kind),
                             author.isEmpty() ? "<deleted>" : author)};
 }
 
 CreateEmoteResult createEmote(const QJsonObject &activeEmote,
-                              const QJsonObject &emoteData, bool isGlobal)
+                              const QJsonObject &emoteData,
+                              SeventvEmoteSetKind kind)
 {
     auto emoteId = EmoteId{activeEmote["id"].toString()};
     auto emoteName = EmoteName{activeEmote["name"].toString()};
@@ -105,8 +122,8 @@ CreateEmoteResult createEmote(const QJsonObject &activeEmote,
     auto tooltip =
         aliasedName
             ? createAliasedTooltip(emoteName.string, baseEmoteName.string,
-                                   author.string, isGlobal)
-            : createTooltip(emoteName.string, author.string, isGlobal);
+                                   author.string, kind)
+            : createTooltip(emoteName.string, author.string, kind);
     auto imageSet = SeventvEmotes::createImageSet(emoteData);
 
     auto emote =
@@ -129,7 +146,7 @@ bool checkEmoteVisibility(const QJsonObject &emoteData)
     return !flags.has(SeventvEmoteFlag::ContentTwitchDisallowed);
 }
 
-EmoteMap parseEmotes(const QJsonArray &emoteSetEmotes, bool isGlobal)
+EmoteMap parseEmotes(const QJsonArray &emoteSetEmotes, SeventvEmoteSetKind kind)
 {
     auto emotes = EmoteMap();
 
@@ -143,7 +160,7 @@ EmoteMap parseEmotes(const QJsonArray &emoteSetEmotes, bool isGlobal)
             continue;
         }
 
-        auto result = createEmote(activeEmote, emoteData, isGlobal);
+        auto result = createEmote(activeEmote, emoteData, kind);
         if (!result.hasImages)
         {
             // this shouldn't happen but if it does, it will crash,
@@ -160,7 +177,8 @@ EmoteMap parseEmotes(const QJsonArray &emoteSetEmotes, bool isGlobal)
 }
 
 EmotePtr createUpdatedEmote(const EmotePtr &oldEmote,
-                            const EmoteUpdateDispatch &dispatch)
+                            const EmoteUpdateDispatch &dispatch,
+                            SeventvEmoteSetKind kind)
 {
     bool toNonAliased = oldEmote->baseName.has_value() &&
                         dispatch.emoteName == oldEmote->baseName->string;
@@ -169,9 +187,9 @@ EmotePtr createUpdatedEmote(const EmotePtr &oldEmote,
     auto emote = std::make_shared<const Emote>(Emote(
         {EmoteName{dispatch.emoteName}, oldEmote->images,
          toNonAliased
-             ? createTooltip(dispatch.emoteName, oldEmote->author.string, false)
+             ? createTooltip(dispatch.emoteName, oldEmote->author.string, kind)
              : createAliasedTooltip(dispatch.emoteName, baseName.string,
-                                    oldEmote->author.string, false),
+                                    oldEmote->author.string, kind),
          oldEmote->homePage, oldEmote->zeroWidth, oldEmote->id,
          oldEmote->author, boost::make_optional(!toNonAliased, baseName)}));
     return emote;
@@ -221,7 +239,8 @@ void SeventvEmotes::loadGlobalEmotes()
         .onSuccess([this](const NetworkResult &result) -> Outcome {
             QJsonArray parsedEmotes = result.parseJson()["emotes"].toArray();
 
-            auto emoteMap = parseEmotes(parsedEmotes, true);
+            auto emoteMap =
+                parseEmotes(parsedEmotes, SeventvEmoteSetKind::Global);
             qCDebug(chatterinoSeventv)
                 << "Loaded" << emoteMap.size() << "7TV Global Emotes";
             this->global_.set(std::make_shared<EmoteMap>(std::move(emoteMap)));
@@ -250,7 +269,8 @@ void SeventvEmotes::loadChannelEmotes(
             auto emoteSet = json["emote_set"].toObject();
             auto parsedEmotes = emoteSet["emotes"].toArray();
 
-            auto emoteMap = parseEmotes(parsedEmotes, false);
+            auto emoteMap =
+                parseEmotes(parsedEmotes, SeventvEmoteSetKind::Channel);
             bool hasEmotes = !emoteMap.empty();
 
             qCDebug(chatterinoSeventv)
@@ -339,7 +359,7 @@ void SeventvEmotes::loadChannelEmotes(
 
 boost::optional<EmotePtr> SeventvEmotes::addEmote(
     Atomic<std::shared_ptr<const EmoteMap>> &map,
-    const EmoteAddDispatch &dispatch)
+    const EmoteAddDispatch &dispatch, SeventvEmoteSetKind kind)
 {
     // Check for visibility first, so we don't copy the map.
     auto emoteData = dispatch.emoteJson["data"].toObject();
@@ -350,7 +370,7 @@ boost::optional<EmotePtr> SeventvEmotes::addEmote(
 
     // This copies the map.
     EmoteMap updatedMap = *map.get();
-    auto result = createEmote(dispatch.emoteJson, emoteData, false);
+    auto result = createEmote(dispatch.emoteJson, emoteData, kind);
     if (!result.hasImages)
     {
         // Incoming emote didn't contain any images, abort
@@ -367,7 +387,7 @@ boost::optional<EmotePtr> SeventvEmotes::addEmote(
 
 boost::optional<EmotePtr> SeventvEmotes::updateEmote(
     Atomic<std::shared_ptr<const EmoteMap>> &map,
-    const EmoteUpdateDispatch &dispatch)
+    const EmoteUpdateDispatch &dispatch, SeventvEmoteSetKind kind)
 {
     auto oldMap = map.get();
     auto oldEmote = oldMap->findEmote(dispatch.emoteName, dispatch.emoteID);
@@ -380,7 +400,7 @@ boost::optional<EmotePtr> SeventvEmotes::updateEmote(
     EmoteMap updatedMap = *map.get();
     updatedMap.erase(oldEmote->second->name);
 
-    auto emote = createUpdatedEmote(oldEmote->second, dispatch);
+    auto emote = createUpdatedEmote(oldEmote->second, dispatch, kind);
     updatedMap[emote->name] = emote;
     map.set(std::make_shared<EmoteMap>(std::move(updatedMap)));
 
@@ -421,7 +441,8 @@ void SeventvEmotes::getEmoteSet(
             auto json = result.parseJson();
             auto parsedEmotes = json["emotes"].toArray();
 
-            auto emoteMap = parseEmotes(parsedEmotes, false);
+            auto emoteMap =
+                parseEmotes(parsedEmotes, SeventvEmoteSetKind::Channel);
 
             qCDebug(chatterinoSeventv) << "Loaded" << emoteMap.size()
                                        << "7TV Emotes from" << emoteSetId;

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -69,6 +69,14 @@ enum class SeventvEmoteSetKind : uint8_t {
     Channel,
 };
 
+enum class SeventvEmoteSetFlag : uint32_t {
+    Immutable = (1 << 0),
+    Privileged = (1 << 1),
+    Personal = (1 << 2),
+    Commercial = (1 << 3),
+};
+using SeventvEmoteSetFlags = FlagsEnum<SeventvEmoteSetFlag>;
+
 class SeventvEmotes final
 {
 public:

--- a/src/providers/seventv/SeventvEmotes.hpp
+++ b/src/providers/seventv/SeventvEmotes.hpp
@@ -63,6 +63,12 @@ struct Emote;
 using EmotePtr = std::shared_ptr<const Emote>;
 class EmoteMap;
 
+enum class SeventvEmoteSetKind : uint8_t {
+    Global,
+    Personal,
+    Channel,
+};
+
 class SeventvEmotes final
 {
 public:
@@ -91,7 +97,8 @@ public:
      */
     static boost::optional<EmotePtr> addEmote(
         Atomic<std::shared_ptr<const EmoteMap>> &map,
-        const seventv::eventapi::EmoteAddDispatch &dispatch);
+        const seventv::eventapi::EmoteAddDispatch &dispatch,
+        SeventvEmoteSetKind kind = SeventvEmoteSetKind::Channel);
 
     /**
      * Updates an emote in this `map`.
@@ -102,7 +109,8 @@ public:
      */
     static boost::optional<EmotePtr> updateEmote(
         Atomic<std::shared_ptr<const EmoteMap>> &map,
-        const seventv::eventapi::EmoteUpdateDispatch &dispatch);
+        const seventv::eventapi::EmoteUpdateDispatch &dispatch,
+        SeventvEmoteSetKind kind = SeventvEmoteSetKind::Channel);
 
     /**
      * Removes an emote from this `map`.

--- a/src/providers/seventv/SeventvEventAPI.cpp
+++ b/src/providers/seventv/SeventvEventAPI.cpp
@@ -7,6 +7,7 @@
 #include "providers/seventv/SeventvBadges.hpp"
 #include "providers/seventv/SeventvCosmetics.hpp"
 #include "providers/seventv/SeventvPaints.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "util/PostToThread.hpp"
 
 #include <QJsonArray>
@@ -51,6 +52,7 @@ void SeventvEventAPI::subscribeTwitchChannel(const QString &id)
             {ChannelCondition{id}, SubscriptionType::CreateEntitlement});
         this->subscribe(
             {ChannelCondition{id}, SubscriptionType::DeleteEntitlement});
+        this->subscribe({ChannelCondition{id}, SubscriptionType::AnyEmoteSet});
     }
 }
 
@@ -82,6 +84,8 @@ void SeventvEventAPI::unsubscribeTwitchChannel(const QString &id)
             {ChannelCondition{id}, SubscriptionType::CreateEntitlement});
         this->unsubscribe(
             {ChannelCondition{id}, SubscriptionType::DeleteEntitlement});
+        this->unsubscribe(
+            {ChannelCondition{id}, SubscriptionType::AnyEmoteSet});
     }
 }
 
@@ -168,6 +172,10 @@ void SeventvEventAPI::handleDispatch(const Dispatch &dispatch)
 {
     switch (dispatch.type)
     {
+        case SubscriptionType::CreateEmoteSet: {
+            this->onEmoteSetCreate(dispatch);
+        }
+        break;
         case SubscriptionType::UpdateEmoteSet: {
             this->onEmoteSetUpdate(dispatch);
         }
@@ -370,6 +378,11 @@ void SeventvEventAPI::onEntitlementCreate(
                 entitlement.refID, UserName{entitlement.userName});
         }
         break;
+        case CosmeticKind::EmoteSet: {
+            Application::instance->seventvPersonalEmotes->assignUserToEmoteSet(
+                entitlement.refID, entitlement.userID);
+        }
+        break;
         default:
             break;
     }
@@ -394,6 +407,25 @@ void SeventvEventAPI::onEntitlementDelete(
         break;
         default:
             break;
+    }
+}
+
+void SeventvEventAPI::onEmoteSetCreate(const Dispatch &dispatch)
+{
+    // We're using Application::instance, because we're not in the GUI thread.
+    // `seventvBadges` and `seventvPaints` do their own locking.
+    EmoteSetCreateDispatch createDispatch(dispatch.body["object"].toObject());
+    if (!createDispatch.validate())
+    {
+        qCDebug(chatterinoSeventvEventAPI)
+            << "Invalid dispatch" << dispatch.body;
+        return;
+    }
+
+    if (createDispatch.isPersonal)
+    {
+        Application::instance->seventvPersonalEmotes->createEmoteSet(
+            createDispatch.emoteSetID);
     }
 }
 // NOLINTEND(readability-convert-member-functions-to-static)

--- a/src/providers/seventv/SeventvEventAPI.cpp
+++ b/src/providers/seventv/SeventvEventAPI.cpp
@@ -379,8 +379,13 @@ void SeventvEventAPI::onEntitlementCreate(
         }
         break;
         case CosmeticKind::EmoteSet: {
-            Application::instance->seventvPersonalEmotes->assignUserToEmoteSet(
-                entitlement.refID, entitlement.userID);
+            if (auto set = Application::instance->seventvPersonalEmotes
+                               ->assignUserToEmoteSet(entitlement.refID,
+                                                      entitlement.userID))
+            {
+                this->signals_.personalEmoteSetAdded.invoke(
+                    {entitlement.userName, *set});
+            }
         }
         break;
         default:

--- a/src/providers/seventv/SeventvEventAPI.hpp
+++ b/src/providers/seventv/SeventvEventAPI.hpp
@@ -84,6 +84,7 @@ private:
         const seventv::eventapi::EntitlementCreateDeleteDispatch &entitlement);
     void onEntitlementDelete(
         const seventv::eventapi::EntitlementCreateDeleteDispatch &entitlement);
+    void onEmoteSetCreate(const seventv::eventapi::Dispatch &dispatch);
 
     /** emote-set ids */
     std::unordered_set<QString> subscribedEmoteSets_;

--- a/src/providers/seventv/SeventvEventAPI.hpp
+++ b/src/providers/seventv/SeventvEventAPI.hpp
@@ -21,6 +21,7 @@ namespace seventv::eventapi {
 
 class SeventvBadges;
 class SeventvPaints;
+class EmoteMap;
 
 class SeventvEventAPI
     : public BasicPubSubManager<seventv::eventapi::Subscription>
@@ -39,6 +40,8 @@ public:
         Signal<seventv::eventapi::EmoteUpdateDispatch> emoteUpdated;
         Signal<seventv::eventapi::EmoteRemoveDispatch> emoteRemoved;
         Signal<seventv::eventapi::UserConnectionUpdateDispatch> userUpdated;
+        Signal<std::pair<QString, std::shared_ptr<const EmoteMap>>>
+            personalEmoteSetAdded;
     } signals_;  // NOLINT(readability-identifier-naming)
 
     /**

--- a/src/providers/seventv/SeventvPersonalEmotes.cpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.cpp
@@ -1,6 +1,7 @@
 #include "providers/seventv/SeventvPersonalEmotes.hpp"
 
 #include "providers/seventv/SeventvEmotes.hpp"
+#include "singletons/Settings.hpp"
 
 #include <boost/optional/optional.hpp>
 
@@ -10,6 +11,16 @@
 #include <utility>
 
 namespace chatterino {
+
+void SeventvPersonalEmotes::initialize(Settings &settings, Paths & /*paths*/)
+{
+    settings.enableSevenTVPersonalEmotes.connect(
+        [this]() {
+            std::unique_lock<std::shared_mutex> lock(this->mutex_);
+            this->enabled_ = Settings::instance().enableSevenTVPersonalEmotes;
+        },
+        this->signalHolder_);
+}
 
 void SeventvPersonalEmotes::createEmoteSet(const QString &id)
 {
@@ -97,6 +108,11 @@ boost::optional<std::shared_ptr<const EmoteMap>>
     SeventvPersonalEmotes::getEmoteSetForUser(const QString &userID) const
 {
     std::shared_lock<std::shared_mutex> lock(this->mutex_);
+    if (!this->enabled_)
+    {
+        return boost::none;
+    }
+
     auto id = this->userEmoteSets_.find(userID);
     if (id == this->userEmoteSets_.end())
     {

--- a/src/providers/seventv/SeventvPersonalEmotes.cpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.cpp
@@ -59,6 +59,15 @@ void SeventvPersonalEmotes::updateEmoteSet(
     }
 }
 
+void SeventvPersonalEmotes::addEmoteSetForUser(const QString &emoteSetID,
+                                               EmoteMap &&map,
+                                               const QString &userTwitchID)
+{
+    std::unique_lock<std::shared_mutex> lock(this->mutex_);
+    this->emoteSets_.emplace(emoteSetID, std::make_shared<const EmoteMap>(map));
+    this->userEmoteSets_[userTwitchID] = emoteSetID;
+}
+
 bool SeventvPersonalEmotes::hasEmoteSet(const QString &id) const
 {
     std::shared_lock<std::shared_mutex> lock(this->mutex_);

--- a/src/providers/seventv/SeventvPersonalEmotes.cpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.cpp
@@ -33,6 +33,12 @@ void SeventvPersonalEmotes::updateEmoteSet(
     auto emoteSet = this->emoteSets_.find(id);
     if (emoteSet != this->emoteSets_.end())
     {
+        // Make sure this emote is actually new to avoid copying the map
+        if (emoteSet->second.get()->contains(
+                EmoteName{dispatch.emoteJson["name"].toString()}))
+        {
+            return;
+        }
         SeventvEmotes::addEmote(emoteSet->second, dispatch,
                                 SeventvEmoteSetKind::Personal);
     }

--- a/src/providers/seventv/SeventvPersonalEmotes.cpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.cpp
@@ -1,0 +1,99 @@
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
+
+#include "providers/seventv/SeventvEmotes.hpp"
+
+#include <boost/optional/optional.hpp>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+
+namespace chatterino {
+
+void SeventvPersonalEmotes::createEmoteSet(const QString &id)
+{
+    std::unique_lock<std::shared_mutex> lock(this->mutex_);
+    if (!this->emoteSets_.contains(id))
+    {
+        this->emoteSets_.emplace(id, std::make_shared<EmoteMap>());
+    }
+}
+
+void SeventvPersonalEmotes::assignUserToEmoteSet(const QString &emoteSetID,
+                                                 const QString &userTwitchID)
+{
+    std::unique_lock<std::shared_mutex> lock(this->mutex_);
+    this->userEmoteSets_.emplace(userTwitchID, emoteSetID);
+}
+
+void SeventvPersonalEmotes::updateEmoteSet(
+    const QString &id, const seventv::eventapi::EmoteAddDispatch &dispatch)
+{
+    std::unique_lock<std::shared_mutex> lock(this->mutex_);
+    auto emoteSet = this->emoteSets_.find(id);
+    if (emoteSet != this->emoteSets_.end())
+    {
+        SeventvEmotes::addEmote(emoteSet->second, dispatch,
+                                SeventvEmoteSetKind::Personal);
+    }
+}
+void SeventvPersonalEmotes::updateEmoteSet(
+    const QString &id, const seventv::eventapi::EmoteUpdateDispatch &dispatch)
+{
+    std::unique_lock<std::shared_mutex> lock(this->mutex_);
+    auto emoteSet = this->emoteSets_.find(id);
+    if (emoteSet != this->emoteSets_.end())
+    {
+        SeventvEmotes::updateEmote(emoteSet->second, dispatch,
+                                   SeventvEmoteSetKind::Personal);
+    }
+}
+void SeventvPersonalEmotes::updateEmoteSet(
+    const QString &id, const seventv::eventapi::EmoteRemoveDispatch &dispatch)
+{
+    std::unique_lock<std::shared_mutex> lock(this->mutex_);
+    auto emoteSet = this->emoteSets_.find(id);
+    if (emoteSet != this->emoteSets_.end())
+    {
+        SeventvEmotes::removeEmote(emoteSet->second, dispatch);
+    }
+}
+
+bool SeventvPersonalEmotes::hasEmoteSet(const QString &id) const
+{
+    std::shared_lock<std::shared_mutex> lock(this->mutex_);
+    return this->emoteSets_.contains(id);
+}
+
+boost::optional<std::shared_ptr<const EmoteMap>>
+    SeventvPersonalEmotes::getEmoteSetForUser(const QString &userID) const
+{
+    std::shared_lock<std::shared_mutex> lock(this->mutex_);
+    auto id = this->userEmoteSets_.find(userID);
+    if (id == this->userEmoteSets_.end())
+    {
+        return boost::none;
+    }
+    auto set = this->emoteSets_.find(id->second);
+    if (set == this->emoteSets_.end())
+    {
+        return boost::none;
+    }
+    return set->second.get();  // copy the shared_ptr
+}
+
+boost::optional<EmotePtr> SeventvPersonalEmotes::getEmoteForUser(
+    const QString &userID, const EmoteName &emoteName) const
+{
+    return this->getEmoteSetForUser(userID).flat_map(
+        [emoteName](const auto &map) -> boost::optional<EmotePtr> {
+            auto it = map->find(emoteName);
+            if (it == map->end())
+            {
+                return boost::none;
+            }
+            return it->second;
+        });
+}
+
+}  // namespace chatterino

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "common/Atomic.hpp"
+#include "common/Singleton.hpp"
+#include "messages/Emote.hpp"
+#include "providers/seventv/eventapi/Dispatch.hpp"
+
+#include <boost/optional.hpp>
+
+#include <memory>
+#include <shared_mutex>
+#include <unordered_map>
+
+namespace chatterino {
+
+class SeventvPersonalEmotes : public Singleton
+{
+public:
+    void createEmoteSet(const QString &id);
+    void assignUserToEmoteSet(const QString &emoteSetID,
+                              const QString &userTwitchID);
+
+    void updateEmoteSet(const QString &id,
+                        const seventv::eventapi::EmoteAddDispatch &dispatch);
+    void updateEmoteSet(const QString &id,
+                        const seventv::eventapi::EmoteUpdateDispatch &dispatch);
+    void updateEmoteSet(const QString &id,
+                        const seventv::eventapi::EmoteRemoveDispatch &dispatch);
+
+    bool hasEmoteSet(const QString &id) const;
+
+    boost::optional<std::shared_ptr<const EmoteMap>> getEmoteSetForUser(
+        const QString &userID) const;
+
+    boost::optional<EmotePtr> getEmoteForUser(const QString &userID,
+                                              const EmoteName &emoteName) const;
+
+private:
+    std::unordered_map<QString, Atomic<std::shared_ptr<const EmoteMap>>>
+        emoteSets_;
+    std::unordered_map<QString, QString> userEmoteSets_;
+    mutable std::shared_mutex mutex_;
+};
+
+}  // namespace chatterino

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -6,6 +6,7 @@
 #include "providers/seventv/eventapi/Dispatch.hpp"
 
 #include <boost/optional.hpp>
+#include <pajlada/signals/signalholder.hpp>
 
 #include <memory>
 #include <shared_mutex>
@@ -16,6 +17,8 @@ namespace chatterino {
 class SeventvPersonalEmotes : public Singleton
 {
 public:
+    void initialize(Settings &settings, Paths &paths) override;
+
     void createEmoteSet(const QString &id);
 
     // Returns the emote-map of this set if it's new.
@@ -48,6 +51,9 @@ private:
     std::unordered_map<QString, QString> userEmoteSets_;
     // userID => userLogin
     std::unordered_map<QString, QString> userLogins_;
+
+    bool enabled_ = true;
+    pajlada::Signals::SignalHolder signalHolder_;
 
     mutable std::shared_mutex mutex_;
 };

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -49,8 +49,6 @@ private:
         emoteSets_;
     // userID => emoteSetID
     std::unordered_map<QString, QString> userEmoteSets_;
-    // userID => userLogin
-    std::unordered_map<QString, QString> userLogins_;
 
     bool enabled_ = true;
     pajlada::Signals::SignalHolder signalHolder_;

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -17,8 +17,10 @@ class SeventvPersonalEmotes : public Singleton
 {
 public:
     void createEmoteSet(const QString &id);
-    void assignUserToEmoteSet(const QString &emoteSetID,
-                              const QString &userTwitchID);
+
+    // Returns the emote-map of this set if it's new.
+    boost::optional<std::shared_ptr<const EmoteMap>> assignUserToEmoteSet(
+        const QString &emoteSetID, const QString &userTwitchID);
 
     void updateEmoteSet(const QString &id,
                         const seventv::eventapi::EmoteAddDispatch &dispatch);
@@ -39,9 +41,14 @@ public:
                                               const EmoteName &emoteName) const;
 
 private:
+    // emoteSetID => emoteSet
     std::unordered_map<QString, Atomic<std::shared_ptr<const EmoteMap>>>
         emoteSets_;
+    // userID => emoteSetID
     std::unordered_map<QString, QString> userEmoteSets_;
+    // userID => userLogin
+    std::unordered_map<QString, QString> userLogins_;
+
     mutable std::shared_mutex mutex_;
 };
 

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -27,6 +27,9 @@ public:
     void updateEmoteSet(const QString &id,
                         const seventv::eventapi::EmoteRemoveDispatch &dispatch);
 
+    void addEmoteSetForUser(const QString &emoteSetID, EmoteMap &&map,
+                            const QString &userTwitchID);
+
     bool hasEmoteSet(const QString &id) const;
 
     boost::optional<std::shared_ptr<const EmoteMap>> getEmoteSetForUser(

--- a/src/providers/seventv/eventapi/Dispatch.cpp
+++ b/src/providers/seventv/eventapi/Dispatch.cpp
@@ -138,4 +138,15 @@ bool EntitlementCreateDeleteDispatch::validate() const
            !this->refID.isEmpty() && this->kind != CosmeticKind::INVALID;
 }
 
+EmoteSetCreateDispatch::EmoteSetCreateDispatch(const QJsonObject &emoteSet)
+    : emoteSetID(emoteSet["id"].toString())
+    , isPersonal((emoteSet["flags"].toInt() & 4) != 0)
+{
+}
+
+bool EmoteSetCreateDispatch::validate() const
+{
+    return !this->emoteSetID.isEmpty();
+}
+
 }  // namespace chatterino::seventv::eventapi

--- a/src/providers/seventv/eventapi/Dispatch.hpp
+++ b/src/providers/seventv/eventapi/Dispatch.hpp
@@ -90,4 +90,13 @@ struct EntitlementCreateDeleteDispatch {
     bool validate() const;
 };
 
+struct EmoteSetCreateDispatch {
+    QString emoteSetID;
+    bool isPersonal;
+
+    EmoteSetCreateDispatch(const QJsonObject &emoteSet);
+
+    bool validate() const;
+};
+
 }  // namespace chatterino::seventv::eventapi

--- a/src/providers/seventv/eventapi/Subscription.hpp
+++ b/src/providers/seventv/eventapi/Subscription.hpp
@@ -12,7 +12,10 @@ namespace chatterino::seventv::eventapi {
 
 // https://github.com/SevenTV/EventAPI/tree/ca4ff15cc42b89560fa661a76c5849047763d334#subscription-types
 enum class SubscriptionType {
+    AnyEmoteSet,
+    CreateEmoteSet,
     UpdateEmoteSet,
+
     UpdateUser,
 
     AnyCosmetic,
@@ -92,6 +95,10 @@ constexpr magic_enum::customize::customize_t magic_enum::customize::enum_name<
     using chatterino::seventv::eventapi::SubscriptionType;
     switch (value)
     {
+        case SubscriptionType::AnyEmoteSet:
+            return "emote_set.*";
+        case SubscriptionType::CreateEmoteSet:
+            return "emote_set.create";
         case SubscriptionType::UpdateEmoteSet:
             return "emote_set.update";
         case SubscriptionType::UpdateUser:

--- a/src/providers/twitch/TwitchAccount.cpp
+++ b/src/providers/twitch/TwitchAccount.cpp
@@ -12,6 +12,8 @@
 #include "messages/MessageBuilder.hpp"
 #include "providers/irc/IrcMessageBuilder.hpp"
 #include "providers/IvrApi.hpp"
+#include "providers/seventv/SeventvEmotes.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/TwitchCommon.hpp"
 #include "providers/twitch/TwitchUser.hpp"
@@ -459,15 +461,50 @@ void TwitchAccount::loadSeventvUserID()
     static const QString seventvUserInfoUrl =
         QStringLiteral("https://7tv.io/v3/users/twitch/%1");
 
+    const auto loadPersonalEmotes = [](const QString &twitchUserID,
+                                       const QString &emoteSetID) {
+        SeventvEmotes::getEmoteSet(
+            emoteSetID,
+            [twitchUserID, emoteSetID](auto &&emoteMap,
+                                       const auto & /*emoteSetName*/) {
+                Application::instance->seventvPersonalEmotes
+                    ->addEmoteSetForUser(
+                        emoteSetID, std::forward<decltype(emoteMap)>(emoteMap),
+                        twitchUserID);
+            },
+            [twitchUserID, emoteSetID](const auto &error) {
+                qCDebug(chatterinoSeventv)
+                    << "Failed to fetch personal emote-set. emote-set-id:"
+                    << emoteSetID << "twitch-user-id" << twitchUserID
+                    << "error:" << error;
+            });
+    };
+
     NetworkRequest(seventvUserInfoUrl.arg(this->getUserId()),
                    NetworkRequestType::Get)
         .timeout(20000)
-        .onSuccess([this](const auto &response) {
+        .onSuccess([this, loadPersonalEmotes](const auto &response) {
             const auto json = response.parseJson();
-            const auto id = json["user"].toObject()["id"].toString();
-            if (!id.isEmpty())
+            const auto user = json["user"].toObject();
+            const auto id = user["id"].toString();
+            if (id.isEmpty())
             {
-                this->seventvUserID_ = id;
+                return Success;
+            }
+
+            this->seventvUserID_ = id;
+
+            for (const auto &emoteSetJson : user["emote_sets"].toArray())
+            {
+                const auto emoteSet = emoteSetJson.toObject();
+                if (SeventvEmoteSetFlags(
+                        SeventvEmoteSetFlag(emoteSet["flags"].toInt()))
+                        .has(SeventvEmoteSetFlag::Personal))
+                {
+                    loadPersonalEmotes(this->getUserId(),
+                                       emoteSet["id"].toString());
+                    break;
+                }
             }
             return Success;
         })

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1658,11 +1658,16 @@ void TwitchChannel::upsertPersonalSeventvEmotes(
 {
     assertInGuiThread();
     auto snapshot = this->getMessageSnapshot();
+    if (snapshot.size() == 0)
+    {
+        return;
+    }
 
     const auto findMessage = [&]() -> std::optional<MessagePtr> {
-        auto end = std::max<size_t>(0, snapshot.size() - 5);
+        auto end = std::max<ptrdiff_t>(0, (ptrdiff_t)snapshot.size() - 5);
 
-        for (size_t i = snapshot.size() - 1; i >= end; i--)
+        // explicitly using signed integers here to represent '-1'
+        for (ptrdiff_t i = (ptrdiff_t)snapshot.size() - 1; i >= end; i--)
         {
             const auto &message = snapshot[i];
             if (message->loginName == userLogin)

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -1708,31 +1708,29 @@ void TwitchChannel::upsertPersonalSeventvEmotes(
                     };
 
                     // Search for a word that matches any emote.
-                    std::for_each(
-                        std::make_move_iterator(textElement->words().begin()),
-                        std::make_move_iterator(textElement->words().end()),
-                        [&](auto &&word) {
-                            auto emoteIt = emoteMap->find(EmoteName{word.text});
-                            if (emoteIt != emoteMap->cend())
+                    for (const auto &word : textElement->words())
+                    {
+                        auto emoteIt = emoteMap->find(EmoteName{word.text});
+                        if (emoteIt != emoteMap->cend())
+                        {
+                            MessageElementFlags emoteFlags(
+                                MessageElementFlag::SevenTVEmote);
+                            if (emoteIt->second->zeroWidth)
                             {
-                                MessageElementFlags emoteFlags(
-                                    MessageElementFlag::SevenTVEmote);
-                                if (emoteIt->second->zeroWidth)
-                                {
-                                    emoteFlags.set(
-                                        MessageElementFlag::ZeroWidthEmote);
-                                }
+                                emoteFlags.set(
+                                    MessageElementFlag::ZeroWidthEmote);
+                            }
 
-                                flush();
-                                elements.emplace_back(
-                                    std::make_unique<EmoteElement>(
-                                        emoteIt->second, emoteFlags));
-                            }
-                            else
-                            {
-                                words.emplace_back(word);
-                            }
-                        });
+                            flush();
+                            elements.emplace_back(
+                                std::make_unique<EmoteElement>(emoteIt->second,
+                                                               emoteFlags));
+                        }
+                        else
+                        {
+                            words.emplace_back(word);
+                        }
+                    }
                     flush();
                 }
                 else

--- a/src/providers/twitch/TwitchChannel.cpp
+++ b/src/providers/twitch/TwitchChannel.cpp
@@ -8,6 +8,7 @@
 #include "common/QLogging.hpp"
 #include "controllers/accounts/AccountController.hpp"
 #include "controllers/notifications/NotificationController.hpp"
+#include "debug/AssertInGuiThread.hpp"
 #include "messages/Emote.hpp"
 #include "messages/Image.hpp"
 #include "messages/Link.hpp"
@@ -45,6 +46,8 @@
 #include <QThread>
 #include <QTimer>
 #include <rapidjson/document.h>
+
+#include <algorithm>
 
 namespace chatterino {
 namespace {
@@ -1648,6 +1651,101 @@ void TwitchChannel::listenSevenTVCosmetics()
         getApp()->twitch->seventvEventAPI->subscribeTwitchChannel(
             this->roomId());
     }
+}
+
+void TwitchChannel::upsertPersonalSeventvEmotes(
+    const QString &userLogin, const std::shared_ptr<const EmoteMap> &emoteMap)
+{
+    assertInGuiThread();
+    auto snapshot = this->getMessageSnapshot();
+
+    const auto findMessage = [&]() -> std::optional<MessagePtr> {
+        auto end = std::max<size_t>(0, snapshot.size() - 5);
+
+        for (size_t i = snapshot.size() - 1; i >= end; i--)
+        {
+            const auto &message = snapshot[i];
+            if (message->loginName == userLogin)
+            {
+                return message;
+            }
+        }
+
+        return std::nullopt;
+    };
+
+    const auto message = findMessage();
+    if (!message)
+    {
+        return;
+    }
+
+    auto cloned = message.value()->cloneWith([&](Message &message) {
+        // We create a new vector of elements,
+        // if we encounter a `TextElement` that contains any emote,
+        // we insert an `EmoteElement` at the position.
+        std::vector<std::unique_ptr<MessageElement>> elements;
+        elements.reserve(message.elements.size());
+
+        std::for_each(
+            std::make_move_iterator(message.elements.begin()),
+            std::make_move_iterator(message.elements.end()),
+            [&](auto &&element) {
+                auto *elementPtr = element.get();
+                auto *textElement = dynamic_cast<TextElement *>(elementPtr);
+
+                // Check if this contains the message text
+                if (textElement != nullptr &&
+                    textElement->getFlags().has(MessageElementFlag::Text))
+                {
+                    std::vector<TextElement::Word> words;
+                    // Append the text element and clear the vector.
+                    const auto flush = [&]() {
+                        elements.emplace_back(std::make_unique<TextElement>(
+                            std::move(words), textElement->getFlags(),
+                            textElement->color(), textElement->style()));
+                        words.clear();
+                    };
+
+                    // Search for a word that matches any emote.
+                    std::for_each(
+                        std::make_move_iterator(textElement->words().begin()),
+                        std::make_move_iterator(textElement->words().end()),
+                        [&](auto &&word) {
+                            auto emoteIt = emoteMap->find(EmoteName{word.text});
+                            if (emoteIt != emoteMap->cend())
+                            {
+                                MessageElementFlags emoteFlags(
+                                    MessageElementFlag::SevenTVEmote);
+                                if (emoteIt->second->zeroWidth)
+                                {
+                                    emoteFlags.set(
+                                        MessageElementFlag::ZeroWidthEmote);
+                                }
+
+                                flush();
+                                elements.emplace_back(
+                                    std::make_unique<EmoteElement>(
+                                        emoteIt->second, emoteFlags));
+                            }
+                            else
+                            {
+                                words.emplace_back(word);
+                            }
+                        });
+                    flush();
+                }
+                else
+                {
+                    elements.emplace_back(
+                        std::forward<decltype(element)>(element));
+                }
+            });
+
+        message.elements = std::move(elements);
+    });
+
+    this->replaceMessage(message.value(), cloned);
 }
 
 }  // namespace chatterino

--- a/src/providers/twitch/TwitchChannel.hpp
+++ b/src/providers/twitch/TwitchChannel.hpp
@@ -174,6 +174,11 @@ public:
     void updateSeventvData(const QString &newUserID,
                            const QString &newEmoteSetID);
 
+    // Update the user's last message and insert the personal emotes if necessary.
+    void upsertPersonalSeventvEmotes(
+        const QString &userLogin,
+        const std::shared_ptr<const EmoteMap> &emoteMap);
+
     // Badges
     boost::optional<EmotePtr> ffzCustomModBadge() const;
     boost::optional<EmotePtr> ffzCustomVipBadge() const;

--- a/src/providers/twitch/TwitchMessageBuilder.cpp
+++ b/src/providers/twitch/TwitchMessageBuilder.cpp
@@ -14,6 +14,7 @@
 #include "providers/colors/ColorProvider.hpp"
 #include "providers/ffz/FfzBadges.hpp"
 #include "providers/seventv/SeventvBadges.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/ChannelPointReward.hpp"
 #include "providers/twitch/PubSubActions.hpp"
@@ -1025,13 +1026,25 @@ Outcome TwitchMessageBuilder::tryAppendEmote(const EmoteName &name)
     auto emote = boost::optional<EmotePtr>{};
 
     // Emote order:
+    //  - 7TV Personal
     //  - FrankerFaceZ Channel
     //  - BetterTTV Channel
     //  - 7TV Channel
     //  - FrankerFaceZ Global
     //  - BetterTTV Global
     //  - 7TV Global
-    if (this->twitchChannel && (emote = this->twitchChannel->ffzEmote(name)))
+    if (this->twitchChannel != nullptr &&
+        (emote =
+             app->seventvPersonalEmotes->getEmoteForUser(this->userId_, name)))
+    {
+        flags = MessageElementFlag::SevenTVEmote;
+        if (emote.value()->zeroWidth)
+        {
+            flags.set(MessageElementFlag::ZeroWidthEmote);
+        }
+    }
+    else if (this->twitchChannel &&
+             (emote = this->twitchChannel->ffzEmote(name)))
     {
         flags = MessageElementFlag::FfzEmote;
     }

--- a/src/singletons/Settings.hpp
+++ b/src/singletons/Settings.hpp
@@ -236,6 +236,8 @@ public:
     BoolSetting enableFFZChannelEmotes = {"/emotes/ffz/channel", true};
     BoolSetting enableSevenTVGlobalEmotes = {"/emotes/seventv/global", true};
     BoolSetting enableSevenTVChannelEmotes = {"/emotes/seventv/channel", true};
+    BoolSetting enableSevenTVPersonalEmotes = {"/emotes/seventv/personal",
+                                               true};
     BoolSetting enableSevenTVEventAPI = {"/emotes/seventv/eventapi", true};
 
     /// Links

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -437,7 +437,7 @@ void EmotePopup::loadChannel(ChannelPtr channel)
                 getApp()->seventvPersonalEmotes->getEmoteSetForUser(
                     getApp()->accounts->twitch.getCurrent()->getUserId()))
         {
-            addEmotes(*channelChannel, *map.get(), "7TV",
+            addEmotes(*subChannel, *map.get(), "7TV",
                       MessageElementFlag::SevenTVEmote);
         }
     }

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -10,6 +10,7 @@
 #include "messages/Message.hpp"
 #include "messages/MessageBuilder.hpp"
 #include "messages/MessageElement.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
@@ -429,6 +430,18 @@ void EmotePopup::loadChannel(ChannelPtr channel)
                   "7TV", MessageElementFlag::SevenTVEmote);
     }
 
+    // personal
+    if (Settings::instance().enableSevenTVPersonalEmotes)
+    {
+        if (const auto map =
+                getApp()->seventvPersonalEmotes->getEmoteSetForUser(
+                    getApp()->accounts->twitch.getCurrent()->getUserId()))
+        {
+            addEmotes(*channelChannel, *map.get(), "7TV",
+                      MessageElementFlag::SevenTVEmote);
+        }
+    }
+
     this->globalEmotesView_->setChannel(globalChannel);
     this->subEmotesView_->setChannel(subChannel);
     this->channelEmotesView_->setChannel(channelChannel);
@@ -524,6 +537,17 @@ void EmotePopup::filterTwitchEmotes(std::shared_ptr<Channel> searchChannel,
     {
         addEmotes(*searchChannel, seventvChannelEmotes, "7TV (Channel)",
                   MessageElementFlag::SevenTVEmote);
+    }
+
+    if (const auto map = getApp()->seventvPersonalEmotes->getEmoteSetForUser(
+            getApp()->accounts->twitch.getCurrent()->getUserId()))
+    {
+        auto seventvPersonalEmotes = filterEmoteMap(searchText, map.get());
+        if (!seventvPersonalEmotes.empty())
+        {
+            addEmotes(*searchChannel, seventvPersonalEmotes,
+                      "SevenTV (Personal)", MessageElementFlag::SevenTVEmote);
+        }
     }
 }
 

--- a/src/widgets/dialogs/EmotePopup.cpp
+++ b/src/widgets/dialogs/EmotePopup.cpp
@@ -431,15 +431,11 @@ void EmotePopup::loadChannel(ChannelPtr channel)
     }
 
     // personal
-    if (Settings::instance().enableSevenTVPersonalEmotes)
+    if (const auto map = getApp()->seventvPersonalEmotes->getEmoteSetForUser(
+            getApp()->accounts->twitch.getCurrent()->getUserId()))
     {
-        if (const auto map =
-                getApp()->seventvPersonalEmotes->getEmoteSetForUser(
-                    getApp()->accounts->twitch.getCurrent()->getUserId()))
-        {
-            addEmotes(*subChannel, *map.get(), "7TV",
-                      MessageElementFlag::SevenTVEmote);
-        }
+        addEmotes(*subChannel, *map.get(), "7TV",
+                  MessageElementFlag::SevenTVEmote);
     }
 
     this->globalEmotesView_->setChannel(globalChannel);

--- a/src/widgets/settingspages/GeneralPage.cpp
+++ b/src/widgets/settingspages/GeneralPage.cpp
@@ -438,8 +438,14 @@ void GeneralPage::initLayout(GeneralPageView &layout)
     layout.addCheckbox("Show FFZ channel emotes", s.enableFFZChannelEmotes);
     layout.addCheckbox("Show 7TV global emotes", s.enableSevenTVGlobalEmotes);
     layout.addCheckbox("Show 7TV channel emotes", s.enableSevenTVChannelEmotes);
-    layout.addCheckbox("Enable 7TV live emote updates (requires restart)",
-                       s.enableSevenTVEventAPI);
+    layout.addCheckbox("Show 7TV personal emotes",
+                       s.enableSevenTVPersonalEmotes, false,
+                       "This requires '7TV live updates' to work.");
+    layout.addCheckbox("Enable 7TV live updates (requires restart)",
+                       s.enableSevenTVEventAPI, false,
+                       "When enabled, channel emotes will get updated "
+                       "automatically (no reload required) and cosmetics "
+                       "(badges/paints/personal emotes) will get updated.");
 
     layout.addTitle("Streamer Mode");
     layout.addDescription(

--- a/src/widgets/splits/InputCompletionPopup.cpp
+++ b/src/widgets/splits/InputCompletionPopup.cpp
@@ -6,6 +6,7 @@
 #include "providers/bttv/BttvEmotes.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
+#include "providers/seventv/SeventvPersonalEmotes.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
@@ -100,6 +101,13 @@ void InputCompletionPopup::updateEmotes(const QString &text, ChannelPtr channel)
 
         if (tc)
         {
+            if (const auto map =
+                    getApp()->seventvPersonalEmotes->getEmoteSetForUser(
+                        getApp()->accounts->twitch.getCurrent()->getUserId()))
+            {
+                addEmotes(emotes, *map.get(), text, "Personal 7TV");
+            }
+
             // TODO extract "Channel {BetterTTV,7TV,FrankerFaceZ}" text into a #define.
             if (auto bttv = tc->bttvEmotes())
             {


### PR DESCRIPTION
Pull request checklist:

- [x] `CHANGELOG.md` was updated, if applicable

# Description

This PR implements personal emotes.

Known bugs/tasks:

- [x] The personal emote set is only fetched after typing a message. So you can't autocomplete emotes immediately.
- [x] Personal emotes only show up in the second message (same issue as for badges).
- ~~Personal emotes are not yet deleted after they haven't been used in a while (the images for the emotes however are deleted as always).~~
- [x] Personal emotes should show in the `Subs` tab instead of `Channel`.
- [x] Only approved personal emotes should be shown.
- [x] Add a setting to disable personal emotes
