### PR TITLE
Remove Flatpackref from Releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -400,11 +400,6 @@ jobs:
           name: chatterino-macos-Qt-5.15.2.dmg
           path: release-artifacts/
 
-      - name: Copy flatpakref
-        run: |
-          cp .CI/chatterino-nightly.flatpakref release-artifacts/
-        shell: bash
-
       - name: Create release
         uses: ncipollo/release-action@v1.12.0
         with:


### PR DESCRIPTION
# Description

This is a reference to the upstream version. There's no flatpack of this fork.
