### PR TITLE
Fix AppImage build for Ubuntu 22.04

### DIFF
--- a/.CI/CreateAppImage.sh
+++ b/.CI/CreateAppImage.sh
@@ -25,6 +25,13 @@ else
     echo "No Qt environment variable set, assuming system-installed Qt"
 fi
 
+if [ -n "$OPENSSL_1_1_1_DIR" ]; then
+    export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$OPENSSL_1_1_1_DIR/lib"
+    export PATH="$OPENSSL_1_1_1_DIR/bin:$PATH"
+else
+    echo "No OpenSSL environment variable set, assuming system-installed OpenSSL"
+fi
+
 script_path=$(readlink -f "$0")
 script_dir=$(dirname "$script_path")
 chatterino_dir=$(dirname "$script_dir")

--- a/.docker/Dockerfile-ubuntu-22.04-base
+++ b/.docker/Dockerfile-ubuntu-22.04-base
@@ -1,6 +1,7 @@
 FROM ubuntu:22.04
 
 ENV TZ=UTC
+ENV OPENSSL_VER=1.1.1w
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
@@ -27,8 +28,20 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
 RUN apt-get -y install \
         git \
         lsb-release \
+        checkinstall \
+        zlib1g-dev \
+        wget \
         python3-pip && \
         apt-get clean all
+        
+        
+#Install OpenSSL 1.1
+RUN wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
+RUN tar xf openssl-$OPENSSL_VER.tar.gz
+RUN cd openssl-$OPENSSL_VER && \
+    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
+    make && \
+    make install
 
 # Install Qt as we do in CI
 

--- a/.docker/Dockerfile-ubuntu-22.04-base
+++ b/.docker/Dockerfile-ubuntu-22.04-base
@@ -40,7 +40,7 @@ RUN wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
 RUN tar xf openssl-$OPENSSL_VER.tar.gz
 RUN cd openssl-$OPENSSL_VER && \
     ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
-    make && \
+    make -j8 && \
     make install
 
 # Install Qt as we do in CI

--- a/.docker/Dockerfile-ubuntu-22.04-build
+++ b/.docker/Dockerfile-ubuntu-22.04-build
@@ -6,7 +6,7 @@ RUN mkdir /src/build
 
 # cmake
 RUN cd /src/build && \
-        CXXFLAGS=-fno-sized-deallocation cmake \
+        OPENSSL_ROOT_DIR=/usr/local/ssl CXXFLAGS=-fno-sized-deallocation cmake \
         -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
         -DCMAKE_PREFIX_PATH=/opt/qt515/lib/cmake \
         -DBUILD_WITH_QTKEYCHAIN=OFF \

--- a/.docker/Dockerfile-ubuntu-22.04-package
+++ b/.docker/Dockerfile-ubuntu-22.04-package
@@ -2,6 +2,7 @@ FROM chatterino-ubuntu-22.04-build
 
 # In CI, this is set from the aqtinstall action
 ENV Qt5_DIR=/opt/qt515
+ENV OPENSSL_1_1_1_DIR=/usr/local/ssl
 
 WORKDIR /src/build
 

--- a/.docker/Dockerfile-ubuntu-22.04-qt6-build
+++ b/.docker/Dockerfile-ubuntu-22.04-qt6-build
@@ -6,6 +6,7 @@ ARG QT_VERSION=6.2.4
 ARG BUILD_WITH_QT6=ON
 
 ENV TZ=UTC
+ENV OPENSSL_VER=1.1.1w
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
@@ -32,8 +33,21 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
 RUN apt-get -y install \
         git \
         lsb-release \
+        checkinstall \
+        zlib1g-dev \
+        wget \
         python3-pip && \
         apt-get clean all
+
+
+#Install OpenSSL 1.1
+RUN wget https://www.openssl.org/source/openssl-$OPENSSL_VER.tar.gz
+RUN tar xf openssl-$OPENSSL_VER.tar.gz
+RUN cd openssl-$OPENSSL_VER && \
+    ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib && \
+    make -j8 && \
+    make install
+
 
 # Install Qt as we do in CI
 
@@ -47,7 +61,7 @@ RUN mkdir /src/build
 
 # cmake
 RUN cd /src/build && \
-        CXXFLAGS=-fno-sized-deallocation cmake \
+        OPENSSL_ROOT_DIR=/usr/local/ssl CXXFLAGS=-fno-sized-deallocation cmake \
         -DBUILD_WITH_QT6=$BUILD_WITH_QT6 \
         -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
         -DCMAKE_PREFIX_PATH=/opt/qt/$QT_VERSION/gcc_64/lib/cmake \

--- a/.docker/Dockerfile-ubuntu-22.04-qt6-package
+++ b/.docker/Dockerfile-ubuntu-22.04-qt6-package
@@ -4,6 +4,7 @@ FROM chatterino-ubuntu-$UBUNTU_VERSION-qt6-build
 
 # In CI, this is set from the aqtinstall action
 ENV Qt6_DIR=/opt/qt/6.2.4/gcc_64
+ENV OPENSSL_1_1_1_DIR=/usr/local/ssl
 
 WORKDIR /src/build
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,13 +103,13 @@ jobs:
         run: |
           echo "C2_BUILD_WITH_QT6=ON" >> "$GITHUB_ENV"
         shell: bash
-        
+
       - name: Set OpenSSL 1.1.1 directory
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
         run: |
-            echo "OPENSSL_1_1_1_DIR=/usr/local/ssl" >> "$GITHUB_ENV"
-        shell: bash 
-           
+          echo "OPENSSL_1_1_1_DIR=/usr/local/ssl" >> "$GITHUB_ENV"
+        shell: bash
+
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -314,13 +314,13 @@ jobs:
       - name: Build OpenSSL 1.1.1
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
         run: |
-            wget "https://www.openssl.org/source/openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
-            tar xf "openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
-            cd "openssl-$OPENSSL_1_1_1_VERSION"
-            ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
-            make -j"$(nproc)"
-            make install
-        shell: bash    
+          wget "https://www.openssl.org/source/openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
+          tar xf "openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
+          cd "openssl-$OPENSSL_1_1_1_VERSION"
+          ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+          make -j"$(nproc)"
+          make install
+        shell: bash
 
       - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
@@ -340,7 +340,6 @@ jobs:
             ..
           make -j"$(nproc)"
         shell: bash
-        
 
       - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '6.')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ env:
   # 2.0.3 has a bug on Windows (conan-io/conan#13606)
   CONAN_VERSION: 2.0.2
   OPENSSL_1_1_1_VERSION: 1.1.1w
+  OPENSSL_1_1_1_SHA256: "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8"
 
 jobs:
   build:
@@ -316,6 +317,7 @@ jobs:
         run: |
           cd $RUNNER_WORKSPACE
           wget "https://www.openssl.org/source/openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
+          echo "${{ env.OPENSSL_1_1_1_SHA256 }}  openssl-$OPENSSL_1_1_1_VERSION.tar.gz" | sha256sum -c
           tar xf "openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
           cd "openssl-$OPENSSL_1_1_1_VERSION"
           ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,6 +314,7 @@ jobs:
       - name: Build OpenSSL 1.1.1
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
         run: |
+          cd $RUNNER_WORKSPACE
           wget "https://www.openssl.org/source/openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
           tar xf "openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
           cd "openssl-$OPENSSL_1_1_1_VERSION"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,7 @@ env:
   CONAN_VERSION: 2.0.2
   OPENSSL_1_1_1_VERSION: 1.1.1w
   OPENSSL_1_1_1_SHA256: "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8"
+  OPENSSL_1_1_1_DIR: /usr/local/ssl
 
 jobs:
   build:
@@ -103,12 +104,6 @@ jobs:
         if: startsWith(matrix.qt-version, '6.')
         run: |
           echo "C2_BUILD_WITH_QT6=ON" >> "$GITHUB_ENV"
-        shell: bash
-
-      - name: Set OpenSSL 1.1.1 directory
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
-        run: |
-          echo "OPENSSL_1_1_1_DIR=/usr/local/ssl" >> "$GITHUB_ENV"
         shell: bash
 
       - uses: actions/checkout@v4
@@ -313,43 +308,24 @@ jobs:
         shell: bash
 
       - name: Build OpenSSL 1.1.1
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           cd $RUNNER_WORKSPACE
           wget "https://www.openssl.org/source/openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
           echo "${{ env.OPENSSL_1_1_1_SHA256 }}  openssl-$OPENSSL_1_1_1_VERSION.tar.gz" | sha256sum -c
           tar xf "openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
           cd "openssl-$OPENSSL_1_1_1_VERSION"
-          ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+          ./config --prefix="$OPENSSL_1_1_1_DIR" --openssldir="$OPENSSL_1_1_1_DIR" shared zlib
           make -j"$(nproc)"
           sudo make install
         shell: bash
 
       - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
+        if: startsWith(matrix.os, 'ubuntu')
         run: |
           mkdir build
           cd build
-          OPENSSL_ROOT_DIR=/usr/local/ssl CXXFLAGS=-fno-sized-deallocation cmake \
-            -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
-            -DUSE_PRECOMPILED_HEADERS=OFF \
-            -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
-            -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
-            -DCHATTERINO_PLUGINS="$C2_PLUGINS" \
-            -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
-            -DCHATTERINO_NO_AVIF_PLUGIN=On \
-            ..
-          make -j"$(nproc)"
-        shell: bash
-
-      - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}
-        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '6.')
-        run: |
-          mkdir build
-          cd build
-          CXXFLAGS=-fno-sized-deallocation cmake \
+          OPENSSL_ROOT_DIR="$OPENSSL_1_1_1_DIR" CXXFLAGS=-fno-sized-deallocation cmake \
             -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
             -DCMAKE_BUILD_TYPE=Release \
             -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -322,7 +322,7 @@ jobs:
           cd "openssl-$OPENSSL_1_1_1_VERSION"
           ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
           make -j"$(nproc)"
-          make install
+          sudo make install
         shell: bash
 
       - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ env:
   # Last known good conan version
   # 2.0.3 has a bug on Windows (conan-io/conan#13606)
   CONAN_VERSION: 2.0.2
+  OPENSSL_1_1_1_VERSION: 1.1.1w
 
 jobs:
   build:
@@ -102,7 +103,13 @@ jobs:
         run: |
           echo "C2_BUILD_WITH_QT6=ON" >> "$GITHUB_ENV"
         shell: bash
-
+        
+      - name: Set OpenSSL 1.1.1 directory
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
+        run: |
+            echo "OPENSSL_1_1_1_DIR=/usr/local/ssl" >> "$GITHUB_ENV"
+        shell: bash 
+           
       - uses: actions/checkout@v4
         with:
           submodules: recursive
@@ -294,7 +301,9 @@ jobs:
               libxcb-image0 \
               libxcb-keysyms1 \
               libxcb-render-util0 \
-              libxcb-xinerama0
+              libxcb-xinerama0 \
+              wget \
+              zlib1g-dev
 
       - name: Apply Qt patches (Ubuntu)
         if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
@@ -302,8 +311,39 @@ jobs:
           patch "$Qt5_DIR/include/QtConcurrent/qtconcurrentthreadengine.h" .patches/qt5-on-newer-gcc.patch
         shell: bash
 
-      - name: Build (Ubuntu)
-        if: startsWith(matrix.os, 'ubuntu')
+      - name: Build OpenSSL 1.1.1
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
+        run: |
+            wget "https://www.openssl.org/source/openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
+            tar xf "openssl-$OPENSSL_1_1_1_VERSION.tar.gz"
+            cd "openssl-$OPENSSL_1_1_1_VERSION"
+            ./config --prefix=/usr/local/ssl --openssldir=/usr/local/ssl shared zlib
+            make -j"$(nproc)"
+            make install
+        shell: bash    
+
+      - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '5.')
+        run: |
+          mkdir build
+          cd build
+          OPENSSL_ROOT_DIR=/usr/local/ssl CXXFLAGS=-fno-sized-deallocation cmake \
+            -DCMAKE_INSTALL_PREFIX=appdir/usr/ \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DPAJLADA_SETTINGS_USE_BOOST_FILESYSTEM=On \
+            -DUSE_PRECOMPILED_HEADERS=OFF \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=On \
+            -DCHATTERINO_LTO="$C2_ENABLE_LTO" \
+            -DCHATTERINO_PLUGINS="$C2_PLUGINS" \
+            -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
+            -DCHATTERINO_NO_AVIF_PLUGIN=On \
+            ..
+          make -j"$(nproc)"
+        shell: bash
+        
+
+      - name: Build (Ubuntu), Qt ${{ matrix.qt-version }}
+        if: startsWith(matrix.os, 'ubuntu') && startsWith(matrix.qt-version, '6.')
         run: |
           mkdir build
           cd build


### PR DESCRIPTION
# Description

Qt 5 needs to link against OpenSSL 1.1.1 but Ubuntu 22.04 only supplies OpenSSL 3.x.  I added a step to build the latest OpenSSL 1.1.1 and link against that when building the AppImage
