### PR TITLE
ci: try to build for both x86 and arm on macOS

### DIFF
--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -25,9 +25,6 @@ if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning force deep inside the app"
     codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force chatterino.app
     echo "Done!"
-else
-    codesign --remove-signature chatterino.app
-    codesign -s - chatterino.app
 fi
 
 echo "Running dmgbuild.."
@@ -38,7 +35,4 @@ if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning the dmg"
     codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force "$OUTPUT_DMG_PATH"
     echo "Done!"
-else
-    codesign --remove-signature "$OUTPUT_DMG_PATH"
-    codesign -s - "$OUTPUT_DMG_PATH"
 fi

--- a/.CI/CreateDMG.sh
+++ b/.CI/CreateDMG.sh
@@ -25,6 +25,9 @@ if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning force deep inside the app"
     codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force chatterino.app
     echo "Done!"
+else
+    codesign --remove-signature chatterino.app
+    codesign -s - chatterino.app
 fi
 
 echo "Running dmgbuild.."
@@ -35,4 +38,7 @@ if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     echo "Codesigning the dmg"
     codesign -s "$MACOS_CODESIGN_CERTIFICATE" --deep --force "$OUTPUT_DMG_PATH"
     echo "Done!"
+else
+    codesign --remove-signature "$OUTPUT_DMG_PATH"
+    codesign -s - "$OUTPUT_DMG_PATH"
 fi

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -35,16 +35,6 @@ fi
 
 macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
-# Download kimageformats plugins
-
-echo "Downloading kimageformats plugins"
-
-curl -SsfLo kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
-echo "Extracting kimageformats plugins"
-7z e -okimg kimg.zip
-cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
-cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/
-
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     # Validate that chatterino.app was codesigned correctly
     codesign -v chatterino.app

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -35,6 +35,11 @@ fi
 
 macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
+echo "Extracting kimageformats plugins"
+7z e -okimg kimg.zip
+cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
+cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/
+
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     # Validate that chatterino.app was codesigned correctly
     codesign -v chatterino.app

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -16,7 +16,7 @@ if [ -n "$Qt5_DIR" ]; then
 elif [ -n "$Qt6_DIR" ]; then
     echo "Using Qt DIR from Qt6_DIR: $Qt6_DIR"
     _QT_DIR="$Qt6_DIR"
-    _img_version="6.5.0"
+    _img_version="6.5.3"
 fi
 
 if [ -n "$_QT_DIR" ]; then
@@ -37,7 +37,7 @@ macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
 # Download kimageformats plugins
 
-curl -SsfLo kimg.zip "https://github.com/jurplel/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
+curl -SsfLo kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
 7z e -okimg kimg.zip
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
 cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -39,7 +39,7 @@ macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
 echo "Downloading kimageformats plugins"
 
-xh -o kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
+curl -SsfLo kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
 echo "Extracting kimageformats plugins"
 7z e -okimg kimg.zip
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -37,7 +37,10 @@ macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
 # Download kimageformats plugins
 
+echo "Downloading kimageformats plugins"
+
 xh -o kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
+echo "Extracting kimageformats plugins"
 7z e -okimg kimg.zip
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
 cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -35,6 +35,14 @@ fi
 
 echo "Extracting kimageformats plugins"
 7z e -okimg kimg.zip
+
+if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
+    echo "Codesigning libKF5Archive"
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --force kimg/libKF5Archive.5.dylib
+    echo "Codesigning kimg_avif"
+    codesign -s "$MACOS_CODESIGN_CERTIFICATE" --force kimg/kimg_avif.so
+fi
+
 mkdir -p chatterino.app/Contents/Frameworks
 mkdir -p chatterino.app/Contents/PlugIns/imageformats
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -16,7 +16,7 @@ if [ -n "$Qt5_DIR" ]; then
 elif [ -n "$Qt6_DIR" ]; then
     echo "Using Qt DIR from Qt6_DIR: $Qt6_DIR"
     _QT_DIR="$Qt6_DIR"
-    _img_version="6.5.3"
+    _img_version="6.5.0"
 fi
 
 if [ -n "$_QT_DIR" ]; then

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -40,7 +40,7 @@ mkdir -p chatterino.app/Contents/PlugIns/imageformats
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
 cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/
 
-macdeployqt chatterino.app "${_macdeployqt_args[@]}" -verbose=3
+macdeployqt chatterino.app "${_macdeployqt_args[@]}" -verbose=1
 
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     # Validate that chatterino.app was codesigned correctly

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -33,12 +33,14 @@ if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     _macdeployqt_args+=("-codesign=$MACOS_CODESIGN_CERTIFICATE")
 fi
 
-macdeployqt chatterino.app "${_macdeployqt_args[@]}"
-
 echo "Extracting kimageformats plugins"
 7z e -okimg kimg.zip
+mkdir -p chatterino.app/Contents/Frameworks
+mkdir -p chatterino.app/Contents/PlugIns/imageformats
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
 cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/
+
+macdeployqt chatterino.app "${_macdeployqt_args[@]}" -verbose=3
 
 if [ -n "$MACOS_CODESIGN_CERTIFICATE" ]; then
     # Validate that chatterino.app was codesigned correctly

--- a/.CI/MacDeploy.sh
+++ b/.CI/MacDeploy.sh
@@ -37,7 +37,7 @@ macdeployqt chatterino.app "${_macdeployqt_args[@]}"
 
 # Download kimageformats plugins
 
-curl -SsfLo kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
+xh -o kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-$_img_version.zip"
 7z e -okimg kimg.zip
 cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
 cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,6 +443,8 @@ jobs:
           pwd
           ls -la build || true
           cd build
+          export MACOS_CODESIGN_CERTIFICATE="-"
+          echo "-> $MACOS_CODESIGN_CERTIFICATE"
 
           brew reinstall openssl
           echo "Downloading kimageformats plugins"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,7 +412,7 @@ jobs:
               brew install $formula
             fi
           done
-          brew install p7zip create-dmg cmake tree
+          brew install p7zip create-dmg cmake tree xh
         shell: bash
 
       - name: Build (MacOS)
@@ -439,7 +439,6 @@ jobs:
         env:
           OUTPUT_DMG_PATH: chatterino-macos-Qt-${{ matrix.qt-version}}-${{ matrix.arch }}.dmg
         run: |
-          brew reinstall openssl
           ls -la
           pwd
           ls -la build || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -401,8 +401,8 @@ jobs:
       - name: Install dependencies (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: |
-          PACKAGES=(boost openssl rapidjson p7zip create-dmg cmake tree libavif)
-          for package in "${PACKAGES[@]}"
+          LIBS=(boost openssl rapidjson)
+          for package in "${LIBS[@]}"
           do
             brew fetch --force --bottle-tag=${{ matrix.arch }}_monterey $package
             formula=$(brew --cache --bottle-tag=${{ matrix.arch }}_monterey $package)
@@ -412,6 +412,7 @@ jobs:
               brew install $formula
             fi
           done
+          brew install p7zip create-dmg cmake tree
         shell: bash
 
       - name: Build (MacOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,19 +443,13 @@ jobs:
           pwd
           ls -la build || true
           cd build
-          ./../.CI/MacDeploy.sh
-
-          echo "Downloading kimageformats plugins"
 
           brew reinstall openssl
+          echo "Downloading kimageformats plugins"
           curl -SsfLo kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-${{ matrix.qt-version}}.zip"
           ${{matrix.arch == 'arm64' && 'brew reinstall $(brew --cache --bottle-tag=arm64_monterey openssl)' || ''}}
 
-          echo "Extracting kimageformats plugins"
-          7z e -okimg kimg.zip
-          cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
-          cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/
-
+          ./../.CI/MacDeploy.sh
           ./../.CI/CreateDMG.sh
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -412,7 +412,7 @@ jobs:
               brew install $formula
             fi
           done
-          brew install p7zip create-dmg cmake tree xh
+          brew install p7zip create-dmg cmake tree
         shell: bash
 
       - name: Build (MacOS)
@@ -443,7 +443,9 @@ jobs:
           pwd
           ls -la build || true
           cd build
+          brew reinstall openssl
           ./../.CI/MacDeploy.sh
+          ${{matrix.arch == 'arm64' && 'brew reinstall $(brew --cache --bottle-tag=arm64_monterey openssl)' || ''}}
           ./../.CI/CreateDMG.sh
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -406,7 +406,11 @@ jobs:
           do
             brew fetch --force --bottle-tag=${{ matrix.arch }}_monterey $package
             formula=$(brew --cache --bottle-tag=${{ matrix.arch }}_monterey $package)
-            brew install $formula
+            if [[ $package == "openssl" ]]; then
+              brew reinstall $formula
+            else
+              brew install $formula
+            fi
           done
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -439,6 +439,7 @@ jobs:
         env:
           OUTPUT_DMG_PATH: chatterino-macos-Qt-${{ matrix.qt-version}}-${{ matrix.arch }}.dmg
         run: |
+          brew reinstall openssl
           ls -la
           pwd
           ls -la build || true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,18 @@ jobs:
             plugins: true
             skip-artifact: false
             skip-crashpad: false
-          # macOS
-          - os: macos-latest
-            qt-version: 5.15.2
+          # macOS (ARM)
+          - os: macos-12
+            qt-version: 6.5.3
+            arch: arm64
+            force-lto: false
+            plugins: false
+            skip-artifact: false
+            skip-crashpad: false
+          # macOS (x86)
+          - os: macos-12
+            qt-version: 6.5.3
+            arch: x86_64
             force-lto: false
             plugins: false
             skip-artifact: false
@@ -392,7 +401,13 @@ jobs:
       - name: Install dependencies (MacOS)
         if: startsWith(matrix.os, 'macos')
         run: |
-          brew install boost openssl rapidjson p7zip create-dmg cmake tree libavif
+          PACKAGES=(boost openssl rapidjson p7zip create-dmg cmake tree libavif)
+          for package in "${PACKAGES[@]}"
+          do
+            brew fetch --force --bottle-tag=${{ matrix.arch }}_monterey $package
+            formula=$(brew --cache --bottle-tag=${{ matrix.arch }}_monterey $package)
+            brew install $formula
+          done
         shell: bash
 
       - name: Build (MacOS)
@@ -409,6 +424,7 @@ jobs:
               -DCHATTERINO_PLUGINS="$C2_PLUGINS" \
               -DBUILD_WITH_QT6="$C2_BUILD_WITH_QT6" \
               -DCHATTERINO_NO_AVIF_PLUGIN=On \
+              -DCMAKE_OSX_ARCHITECTURES=${{ matrix.arch }} \
               ..
           make -j"$(sysctl -n hw.logicalcpu)"
         shell: bash
@@ -416,7 +432,7 @@ jobs:
       - name: Package (MacOS)
         if: startsWith(matrix.os, 'macos')
         env:
-          OUTPUT_DMG_PATH: chatterino-macos-Qt-${{ matrix.qt-version}}.dmg
+          OUTPUT_DMG_PATH: chatterino-macos-Qt-${{ matrix.qt-version}}-${{ matrix.arch }}.dmg
         run: |
           ls -la
           pwd
@@ -430,8 +446,8 @@ jobs:
         if: startsWith(matrix.os, 'macos')
         uses: actions/upload-artifact@v4
         with:
-          name: chatterino-macos-Qt-${{ matrix.qt-version }}.dmg
-          path: build/chatterino-macos-Qt-${{ matrix.qt-version }}.dmg
+          name: chatterino-macos-Qt-${{ matrix.qt-version }}-${{ matrix.arch }}.dmg
+          path: build/chatterino-macos-Qt-${{ matrix.qt-version }}-${{ matrix.arch }}.dmg
   create-release:
     needs: build
     runs-on: ubuntu-latest
@@ -479,16 +495,23 @@ jobs:
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
-        name: macOS x86_64 Qt5.15.2 dmg
+        name: macOS x86_64 Qt6.5.3 x86 dmg
         with:
-          name: chatterino-macos-Qt-5.15.2.dmg
+          name: chatterino-macos-Qt-6.5.3-x86_64.dmg
+          path: release-artifacts/
+
+      - uses: actions/download-artifact@v4
+        name: macOS x86_64 Qt6.5.3 ARM dmg
+        with:
+          name: chatterino-macos-Qt-6.5.3-arm64.dmg
           path: release-artifacts/
 
       - name: Rename artifacts
         run: |
           ls -l
-          # Rename the macos build to indicate that it's for macOS 10.15 users
-          mv chatterino-macos-Qt-5.15.2.dmg Chatterino-macOS-12.0.dmg
+          # Rename the macos build to indicate that it's for macOS 12.0 users
+          mv chatterino-macos-Qt-6.5.3-x86_64.dmg Chatterino-macOS-12.0-x86_64.dmg
+          mv chatterino-macos-Qt-6.5.3-arm64.dmg Chatterino-macOS-12.0-arm64.dmg
         working-directory: release-artifacts
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -443,9 +443,19 @@ jobs:
           pwd
           ls -la build || true
           cd build
-          brew reinstall openssl
           ./../.CI/MacDeploy.sh
+
+          echo "Downloading kimageformats plugins"
+
+          brew reinstall openssl
+          curl -SsfLo kimg.zip "https://github.com/nerixyz/kimageformats-binaries/releases/download/cont/kimageformats-macos-latest-${{ matrix.qt-version}}.zip"
           ${{matrix.arch == 'arm64' && 'brew reinstall $(brew --cache --bottle-tag=arm64_monterey openssl)' || ''}}
+
+          echo "Extracting kimageformats plugins"
+          7z e -okimg kimg.zip
+          cp kimg/libKF5Archive.5.dylib chatterino.app/Contents/Frameworks/
+          cp kimg/kimg_avif.so chatterino.app/Contents/PlugIns/imageformats/
+
           ./../.CI/CreateDMG.sh
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
             skip-crashpad: false
           # macOS (ARM)
           - os: macos-12
-            qt-version: 6.5.3
+            qt-version: 6.5.0
             arch: arm64
             force-lto: false
             plugins: false
@@ -63,7 +63,7 @@ jobs:
             skip-crashpad: false
           # macOS (x86)
           - os: macos-12
-            qt-version: 6.5.3
+            qt-version: 6.5.0
             arch: x86_64
             force-lto: false
             plugins: false
@@ -495,23 +495,23 @@ jobs:
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
-        name: macOS x86_64 Qt6.5.3 x86 dmg
+        name: macOS x86_64 Qt6.5.0 x86 dmg
         with:
-          name: chatterino-macos-Qt-6.5.3-x86_64.dmg
+          name: chatterino-macos-Qt-6.5.0-x86_64.dmg
           path: release-artifacts/
 
       - uses: actions/download-artifact@v4
-        name: macOS x86_64 Qt6.5.3 ARM dmg
+        name: macOS x86_64 Qt6.5.0 ARM dmg
         with:
-          name: chatterino-macos-Qt-6.5.3-arm64.dmg
+          name: chatterino-macos-Qt-6.5.0-arm64.dmg
           path: release-artifacts/
 
       - name: Rename artifacts
         run: |
           ls -l
           # Rename the macos build to indicate that it's for macOS 12.0 users
-          mv chatterino-macos-Qt-6.5.3-x86_64.dmg Chatterino-macOS-12.0-x86_64.dmg
-          mv chatterino-macos-Qt-6.5.3-arm64.dmg Chatterino-macOS-12.0-arm64.dmg
+          mv chatterino-macos-Qt-6.5.0-x86_64.dmg Chatterino-macOS-12.0-x86_64.dmg
+          mv chatterino-macos-Qt-6.5.0-arm64.dmg Chatterino-macOS-12.0-arm64.dmg
         working-directory: release-artifacts
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build:
-    name: "Build ${{ matrix.os }}, Qt ${{ matrix.qt-version }} (LTO:${{ matrix.force-lto }}, crashpad:${{ matrix.skip-crashpad && 'off' || 'on' }})"
+    name: "Build ${{ matrix.os }}${{ matrix.arch && format(' ({0})', matrix.arch) || ''}}, Qt ${{ matrix.qt-version }} (LTO:${{ matrix.force-lto }}, crashpad:${{ matrix.skip-crashpad && 'off' || 'on' }})"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -145,14 +145,15 @@ jobs:
         run: |
           ls -l
           mv Chatterino-ubuntu-22.04-Qt-5.15.2.deb Chatterino-Ubuntu-22.04.deb
-          mv Chatterino-ubuntu-22.04-Qt-6.2.4.deb EXPERIMENTAL-Chatterino-Ubuntu-22.04-Qt6.deb
+          mv Chatterino-ubuntu-22.04-Qt-6.2.4.deb Chatterino-Ubuntu-22.04-Qt6.deb
 
           mv Chatterino-x86_64-5.15.2.AppImage Chatterino-x86_64.AppImage
-          mv Chatterino-x86_64-6.2.4.AppImage EXPERIMENTAL-Chatterino-x86_64-Qt6.AppImage
+          mv Chatterino-x86_64-6.2.4.AppImage Chatterino-x86_64-Qt6.AppImage
 
           mv chatterino-windows-x86-64-Qt-6.5.0-symbols.pdb.7z Chatterino-Windows-debug-symbols.pdb.7z
 
-          mv chatterino-macos-Qt-5.15.2.dmg Chatterino.dmg
+          mv chatterino-macos-Qt-6.5.3-x86_64.dmg Chatterino-x86_64.dmg
+          mv chatterino-macos-Qt-6.5.3-arm64.dmg Chatterino-arm64.dmg
 
       - name: Hash files
         working-directory: build

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -152,8 +152,8 @@ jobs:
 
           mv chatterino-windows-x86-64-Qt-6.5.0-symbols.pdb.7z Chatterino-Windows-debug-symbols.pdb.7z
 
-          mv chatterino-macos-Qt-6.5.3-x86_64.dmg Chatterino-x86_64.dmg
-          mv chatterino-macos-Qt-6.5.3-arm64.dmg Chatterino-arm64.dmg
+          mv chatterino-macos-Qt-6.5.0-x86_64.dmg Chatterino-x86_64.dmg
+          mv chatterino-macos-Qt-6.5.0-arm64.dmg Chatterino-arm64.dmg
 
       - name: Hash files
         working-directory: build


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Regarding https://github.com/SevenTV/chatterino7/issues/225. Not sure if this works, but seems worth a try.

I'm updating to my fork of kimageformats, since I build with Qt 6.5.0 there.

I can't use 6.5.3 because of [QTBUG-120579](https://bugreports.qt.io/browse/QTBUG-120579) (soon though 🙂).