### PR TITLE
refactor: use raw pixmap filters for paints

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -7,3 +7,4 @@
 - Dev: Updated Conan version used in CI to 2.4 (330d05d50ffd296b34744dbcc97290534e8cf704)
 - Dev(Windows): Updated `libavif` to 1.0.4, `boost` to 1.85, and `openssl` to 3.2.2 (330d05d50ffd296b34744dbcc97290534e8cf704)
 - Dev(macOS): A single universal app is now released for macOS (#274)
+- Dev: Refactored paints to avoid creation of intermediate widgets (#277)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -783,6 +783,7 @@ target_link_libraries(${LIBRARY_PROJECT}
         PUBLIC
         Qt${MAJOR_QT_VERSION}::Core
         Qt${MAJOR_QT_VERSION}::Widgets
+        Qt${MAJOR_QT_VERSION}::WidgetsPrivate # for pixmap filters (paints)
         Qt${MAJOR_QT_VERSION}::Gui
         Qt${MAJOR_QT_VERSION}::Network
         Qt${MAJOR_QT_VERSION}::Svg

--- a/src/messages/MessageElement.cpp
+++ b/src/messages/MessageElement.cpp
@@ -573,7 +573,8 @@ void TextElement::addToContainer(MessageLayoutContainer &container,
 
                 auto *e = new TextLayoutElement(
                     *this, text, QSize(width, metrics.height()), color,
-                    this->style_, this->color_.type(), container.getScale());
+                    this->style_, this->color_.type(), container.getScale(),
+                    container.getImageScale() / container.getScale());
                 e->setTrailingSpace(hasTrailingSpace);
                 e->setText(text);
                 e->setWordId(wordId);

--- a/src/messages/layouts/MessageLayoutElement.cpp
+++ b/src/messages/layouts/MessageLayoutElement.cpp
@@ -421,12 +421,13 @@ TextLayoutElement::TextLayoutElement(MessageElement &_creator, QString &_text,
                                      const QSize &_size, QColor _color,
                                      FontStyle _style,
                                      MessageColor::Type messageColor,
-                                     float _scale)
+                                     float _scale, float dpr)
     : MessageLayoutElement(_creator, _size)
     , color_(_color)
     , style_(_style)
     , messageColor_(messageColor)
     , scale_(_scale)
+    , dpr_(dpr)
 {
     this->setText(_text);
 }
@@ -476,11 +477,9 @@ void TextLayoutElement::paint(QPainter &painter,
 
         auto paintPixmap =
             paint->getPixmap(this->getText(), font, this->color_,
-                             this->getRect().size(), this->scale_);
+                             this->getRect().size(), this->scale_, this->dpr_);
 
-        painter.drawPixmap(QRect(this->getRect().x(), this->getRect().y(),
-                                 paintPixmap.width(), paintPixmap.height()),
-                           paintPixmap);
+        painter.drawPixmap(this->getRect().topLeft(), paintPixmap);
     }
     else
     {
@@ -516,7 +515,7 @@ bool TextLayoutElement::paintAnimated(QPainter &painter, const int yOffset)
 
         const auto paintPixmap =
             paint->getPixmap(this->getText(), font, this->color_,
-                             this->getRect().size(), this->scale_);
+                             this->getRect().size(), this->scale_, this->dpr_);
 
         auto rect = this->getRect();
         rect.moveTop(rect.y() + yOffset);

--- a/src/messages/layouts/MessageLayoutElement.hpp
+++ b/src/messages/layouts/MessageLayoutElement.hpp
@@ -171,7 +171,8 @@ class TextLayoutElement : public MessageLayoutElement
 public:
     TextLayoutElement(MessageElement &creator_, QString &text,
                       const QSize &size, QColor color_, FontStyle style_,
-                      MessageColor::Type messageColor, float scale_);
+                      MessageColor::Type messageColor, float scale_,
+                      float dpr = 1.0F);
 
 protected:
     void addCopyTextToString(QString &str, uint32_t from = 0,
@@ -188,6 +189,7 @@ protected:
     // space (fits in the padding of `style_`)
     MessageColor::Type messageColor_;
     float scale_;
+    float dpr_ = 1.0F;  // for 7tv paints
 };
 
 // TEXT ICON

--- a/src/providers/seventv/paints/Paint.hpp
+++ b/src/providers/seventv/paints/Paint.hpp
@@ -17,7 +17,7 @@ public:
     virtual bool animated() const = 0;
 
     QPixmap getPixmap(const QString &text, const QFont &font, QColor userColor,
-                      QSize size, float scale) const;
+                      QSize size, float scale, float dpr) const;
 
     Paint(QString id)
         : id(std::move(id)){};

--- a/src/providers/seventv/paints/PaintDropShadow.cpp
+++ b/src/providers/seventv/paints/PaintDropShadow.cpp
@@ -1,5 +1,7 @@
 #include "providers/seventv/paints/PaintDropShadow.hpp"
 
+#include <private/qpixmapfilter_p.h>
+
 namespace chatterino {
 
 PaintDropShadow::PaintDropShadow(float xOffset, float yOffset, float radius,
@@ -22,11 +24,9 @@ PaintDropShadow PaintDropShadow::scaled(float scale) const
             this->radius_ * scale, this->color_};
 }
 
-void PaintDropShadow::apply(QGraphicsDropShadowEffect &effect) const
+void PaintDropShadow::apply(QPixmapDropShadowFilter &effect) const
 {
-    // We can't move here
-    effect.setXOffset(this->xOffset_);
-    effect.setYOffset(this->yOffset_);
+    effect.setOffset({this->xOffset_, this->yOffset_});
     effect.setBlurRadius(this->radius_);
     effect.setColor(this->color_);
 }

--- a/src/providers/seventv/paints/PaintDropShadow.hpp
+++ b/src/providers/seventv/paints/PaintDropShadow.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <QGraphicsDropShadowEffect>
+class QPixmapDropShadowFilter;
 
 namespace chatterino {
 
@@ -11,7 +11,7 @@ public:
 
     bool isValid() const;
     PaintDropShadow scaled(float scale) const;
-    void apply(QGraphicsDropShadowEffect &effect) const;
+    void apply(QPixmapDropShadowFilter &effect) const;
 
 private:
     const float xOffset_;

--- a/src/providers/seventv/paints/PaintDropShadow.hpp
+++ b/src/providers/seventv/paints/PaintDropShadow.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <QColor>
+
 class QPixmapDropShadowFilter;
 
 namespace chatterino {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

I'd rather use a (stable) private API than create a bunch of widgets when painting paints. From what it seems, this improves paints on high-dpi displays too (?) not sure.