### PR TITLE
feat: support 7TV overrides and emoji-emotes

### DIFF
--- a/src/messages/Emote.hpp
+++ b/src/messages/Emote.hpp
@@ -19,6 +19,7 @@ struct Emote {
     Tooltip tooltip;
     Url homePage;
     bool zeroWidth{};
+    bool isGlobalOverride = false;
     EmoteId id;
     EmoteAuthor author;
     /**

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -2133,24 +2133,6 @@ void MessageBuilder::addEmoji(const EmotePtr &emote)
 
 void MessageBuilder::addTextOrEmote(TextState &state, QString string)
 {
-    if (state.hasBits && this->tryAppendCheermote(state, string))
-    {
-        // This string was parsed as a cheermote
-        return;
-    }
-
-    // TODO: Implement ignored emotes
-    // Format of ignored emotes:
-    // Emote name: "forsenPuke" - if string in ignoredEmotes
-    // Will match emote regardless of source (i.e. bttv, ffz)
-    // Emote source + name: "bttv:nyanPls"
-    if (this->tryAppendEmote(state.twitchChannel, state.userID, {string}))
-    {
-        // Successfully appended an emote
-        return;
-    }
-
-    // Actually just text
     auto link = linkparser::parse(string);
     auto textColor = this->textColor_;
 
@@ -2764,7 +2746,25 @@ void MessageBuilder::addWords(
             continue;
         }
 
-        // split words
+        if (state.hasBits && this->tryAppendCheermote(state, word))
+        {
+            // This string was parsed as a cheermote
+            cursor += word.size() + 1;
+            continue;
+        }
+
+        // TODO: Implement ignored emotes
+        // Format of ignored emotes:
+        // Emote name: "forsenPuke" - if string in ignoredEmotes
+        // Will match emote regardless of source (i.e. bttv, ffz)
+        // Emote source + name: "bttv:nyanPls"
+        if (this->tryAppendEmote(state.twitchChannel, state.userID, {word}))
+        {
+            // Successfully appended an emote
+            cursor += word.size() + 1;
+            continue;
+        }
+
         for (auto variant : getApp()->getEmotes()->getEmojis()->parse(word))
         {
             boost::apply_visitor(variant::Overloaded{

--- a/src/messages/MessageBuilder.hpp
+++ b/src/messages/MessageBuilder.hpp
@@ -269,6 +269,8 @@ private:
     Outcome tryAppendCheermote(TextState &state, const QString &string);
     Outcome tryAppendEmote(TwitchChannel *twitchChannel, const QString &userID,
                            const EmoteName &name);
+    void appendEmote(const EmotePtr &emote, MessageElementFlags flags,
+                     bool zeroWidth);
 
     bool isEmpty() const;
     MessageElement &back();

--- a/src/providers/bttv/BttvEmotes.cpp
+++ b/src/providers/bttv/BttvEmotes.cpp
@@ -109,6 +109,7 @@ CreateEmoteResult createChannelEmote(const QString &channelDisplayName,
                                              : author.string)},
         Url{EMOTE_LINK_FORMAT.arg(id.string)},
         false,
+        false,
         id,
     });
 

--- a/tests/snapshots/IrcMessageHandler/rm-deleted.json
+++ b/tests/snapshots/IrcMessageHandler/rm-deleted.json
@@ -179,39 +179,19 @@
                     ]
                 },
                 {
-                    "emote": {
-                        "author": "Chatterino",
-                        "homePage": "https://chatterino.com/7TVEmote",
-                        "id": "1",
-                        "images": {
-                            "1x": "https://chatterino.com/7TVEmote.png"
-                        },
-                        "name": "7TVEmote",
-                        "tooltip": "7TVEmote Tooltip"
-                    },
-                    "flags": "SevenTVEmoteImage|SevenTVEmoteText",
+                    "color": "Text",
+                    "flags": "Text",
                     "link": {
                         "type": "None",
                         "value": ""
                     },
-                    "text": {
-                        "color": "Text",
-                        "flags": "Misc",
-                        "link": {
-                            "type": "None",
-                            "value": ""
-                        },
-                        "style": "ChatMedium",
-                        "tooltip": "",
-                        "trailingSpace": true,
-                        "type": "TextElement",
-                        "words": [
-                            "7TVEmote"
-                        ]
-                    },
-                    "tooltip": "7TVEmote Tooltip",
+                    "style": "ChatMedium",
+                    "tooltip": "",
                     "trailingSpace": true,
-                    "type": "EmoteElement"
+                    "type": "TextElement",
+                    "words": [
+                        "7TVEmote"
+                    ]
                 },
                 {
                     "emote": {


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

- Supports overrides of emotes (technically for any provider, but only 7TV has that feature)
- Supports emotes with emojis in their name.
  This changes the parsing a bit (for the better, imo), since we parse emojis after emotes now. The next step would be to correctly set the trailing space if an emoji is found in a word (that's for c2 or if users complain).