### PR TITLE
fix: add missing dependency for building on fedora

### DIFF
--- a/BUILDING_ON_LINUX.md
+++ b/BUILDING_ON_LINUX.md
@@ -33,7 +33,7 @@ Alternatively you can use the [chatterino2-git](https://aur.archlinux.org/packag
 _Most likely works the same for other Red Hat-like distros. Substitute `dnf` with `yum`._
 
 ```sh
-sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qt5compat-devel g++ git openssl-devel boost-devel cmake
+sudo dnf install qt6-qtbase-devel qt6-qtimageformats qt6-qtsvg-devel qt6-qtbase-private-devel qt6-qt5compat-devel g++ git openssl-devel boost-devel cmake
 ```
 
 ### NixOS 18.09+


### PR DESCRIPTION
This adds a missing dependency for building on Fedora 41. Without this package I got the following cmake error: 
```
-- Configuring done (1.0s)
CMake Error in src/CMakeLists.txt:
  Imported target "Qt6::WidgetsPrivate" includes non-existent path

    "/usr/include/qt6/QtWidgets/6.8.0"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.



CMake Error in src/CMakeLists.txt:
  Imported target "Qt6::WidgetsPrivate" includes non-existent path

    "/usr/include/qt6/QtWidgets/6.8.0"

  in its INTERFACE_INCLUDE_DIRECTORIES.  Possible reasons include:

  * The path was deleted, renamed, or moved to another location.

  * An install or uninstall procedure did not complete successfully.

  * The installation package was faulty and references files it does not
  provide.



-- Generating done (0.1s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```

This error does not pop up and cmake configures correctly if `qt6-qtbase-private-devel` is installed.