### PR TITLE
feat: cache paints

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -6,6 +6,7 @@
 - Bugfix: Opening the avatar of a user from a usercard in the browser now opens the correct URL (c8a096c868864e0a51911640534d3e3283298bda)
 - Bugfix: If a user never set their 7TV avatar, the usercard will no longer show a button to switch between Twitch and 7TV (519a2c3174a96fc19cf59a87005dda07c344b04a)
 - Bugfix: Fixed mentions becoming unclickable when a user updated/announced their personal emotes (7ed952b61073e3081ab1377d1429f554f71b6a07)
+- Dev: Paints are now cached - at most eight paints will be cached concurrently (#302)
 
 ## 7.5.2-beta.1
 

--- a/src/messages/Image.cpp
+++ b/src/messages/Image.cpp
@@ -186,6 +186,11 @@ std::optional<QPixmap> Frames::first() const
     return this->items_.front().image;
 }
 
+int Frames::durationOffset() const noexcept
+{
+    return this->durationOffset_;
+}
+
 QList<Frame> readFrames(QImageReader &reader, const Url &url)
 {
     QList<Frame> frames;
@@ -436,6 +441,11 @@ bool Image::animated() const
     assertInGuiThread();
 
     return this->frames_->animated();
+}
+
+int Image::durationOffset() const noexcept
+{
+    return this->frames_->durationOffset();
 }
 
 int Image::width() const

--- a/src/messages/Image.hpp
+++ b/src/messages/Image.hpp
@@ -49,6 +49,7 @@ public:
     void advance();
     std::optional<QPixmap> current() const;
     std::optional<QPixmap> first() const;
+    int durationOffset() const noexcept;
 
 private:
     int64_t memoryUsage() const;
@@ -99,6 +100,7 @@ public:
     int width() const;
     int height() const;
     bool animated() const;
+    int durationOffset() const noexcept;
 
     bool operator==(const Image &image) = delete;
     bool operator!=(const Image &image) = delete;

--- a/src/providers/seventv/paints/Paint.cpp
+++ b/src/providers/seventv/paints/Paint.cpp
@@ -9,6 +9,40 @@
 #include <QLabel>
 #include <QPainter>
 
+namespace {
+struct CacheEntry {
+    size_t hash = 0;
+    int offset = 0;
+    QPixmap pix;
+};
+
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+constinit std::array<std::optional<CacheEntry>, 8> CACHE;
+
+// NOLINTBEGIN(cppcoreguidelines-pro-bounds-constant-array-index)
+bool getFromCache(size_t hash, int offset, QPixmap *pix)
+{
+    auto &it = CACHE[hash % CACHE.size()];
+    if (!it || it->hash != hash || it->offset != offset)
+    {
+        return false;
+    }
+    *pix = it->pix;
+    return true;
+}
+
+void putToCache(size_t hash, int offset, const QPixmap &pix)
+{
+    CACHE[hash % CACHE.size()] = CacheEntry{
+        .hash = hash,
+        .offset = offset,
+        .pix = pix,
+    };
+}
+// NOLINTEND(cppcoreguidelines-pro-bounds-constant-array-index)
+
+}  // namespace
+
 namespace chatterino {
 
 using namespace literals;
@@ -17,7 +51,15 @@ QPixmap Paint::getPixmap(const QString &text, const QFont &font,
                          QColor userColor, QSize size, float scale,
                          float dpr) const
 {
-    QPixmap pixmap(size * dpr);
+    int durationOffset = this->durationOffset();
+    size_t hash =
+        qHashMulti(0, this->id, text, font, userColor.rgba(), size, scale, dpr);
+    QPixmap pixmap;
+    if (getFromCache(hash, durationOffset, &pixmap))
+    {
+        return pixmap;
+    }
+    pixmap = QPixmap(size * dpr);
     pixmap.setDevicePixelRatio(dpr);
     pixmap.fill(Qt::transparent);
 
@@ -88,6 +130,8 @@ QPixmap Paint::getPixmap(const QString &text, const QFont &font,
                                QTextOption(Qt::AlignLeft | Qt::AlignTop));
         pixmapPainter.end();
     }
+
+    putToCache(hash, durationOffset, pixmap);
 
     return pixmap;
 }

--- a/src/providers/seventv/paints/Paint.hpp
+++ b/src/providers/seventv/paints/Paint.hpp
@@ -24,7 +24,7 @@ public:
                       QSize size, float scale, float dpr) const;
 
     Paint(QString id)
-        : id(std::move(id)) {};
+        : id(std::move(id)){};
     virtual ~Paint() = default;
 
     Paint(const Paint &) = default;

--- a/src/providers/seventv/paints/Paint.hpp
+++ b/src/providers/seventv/paints/Paint.hpp
@@ -15,12 +15,16 @@ public:
     virtual QBrush asBrush(QColor userColor, QRectF drawingRect) const = 0;
     virtual const std::vector<PaintDropShadow> &getDropShadows() const = 0;
     virtual bool animated() const = 0;
+    virtual int durationOffset() const noexcept
+    {
+        return 0;
+    };
 
     QPixmap getPixmap(const QString &text, const QFont &font, QColor userColor,
                       QSize size, float scale, float dpr) const;
 
     Paint(QString id)
-        : id(std::move(id)){};
+        : id(std::move(id)) {};
     virtual ~Paint() = default;
 
     Paint(const Paint &) = default;

--- a/src/providers/seventv/paints/UrlPaint.cpp
+++ b/src/providers/seventv/paints/UrlPaint.cpp
@@ -20,6 +20,11 @@ bool UrlPaint::animated() const
     return image_->animated();
 }
 
+int UrlPaint::durationOffset() const noexcept
+{
+    return this->image_->durationOffset();
+}
+
 QBrush UrlPaint::asBrush(const QColor userColor, const QRectF drawingRect) const
 {
     if (auto paintPixmap = this->image_->pixmapOrLoad())

--- a/src/providers/seventv/paints/UrlPaint.hpp
+++ b/src/providers/seventv/paints/UrlPaint.hpp
@@ -14,6 +14,7 @@ public:
     QBrush asBrush(QColor userColor, QRectF drawingRect) const override;
     const std::vector<PaintDropShadow> &getDropShadows() const override;
     bool animated() const override;
+    int durationOffset() const noexcept override;
 
 private:
     const QString name_;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Not sure about the size, maybe 16 are better? How big are the pixmaps? Maybe 80x20 → (512KB, 1MB).