### PR TITLE
fix: typo in color input selector. changed from red to blue

### DIFF
--- a/src/widgets/helper/color/ColorInput.cpp
+++ b/src/widgets/helper/color/ColorInput.cpp
@@ -82,7 +82,7 @@ ColorInput::ColorInput(QColor color, QWidget *parent)
     initComponent(this->green_, "Green:", [](auto &color, int value) {
         color.setGreen(value);
     });
-    initComponent(this->blue_, "Red:", [](auto &color, int value) {
+    initComponent(this->blue_, "Blue:", [](auto &color, int value) {
         color.setBlue(value);
     });
     initComponent(this->alpha_, "Alpha:", [](auto &color, int value) {


### PR DESCRIPTION
Changed the label for "Blue" back to Blue as it was incorrectly changed to "Red". This bug was introduced in commit 78a7ebb9f952d4de8fb69b95a786e570e96bdf1c.

To replicate this bug, open any of the color picker windows. One example is the "Highlights" menu.
![image](https://github.com/user-attachments/assets/1a6f8d1f-57cf-44dd-82d9-4e56f4234af6)
