### PR TITLE
feat: Adjusted about page to show 7TV Specific traits

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,11 +2,11 @@
 
 ## Unreleased
 
+- Minor: Added 7TV Discord link to about section and changed the commit link to point to SevenTV/Chatterino7 (#305)
 - Bugfix: Fixed special 7TV emote sets not being applied and not showing in chat (5cc89d3ba9c11b9e0d36be9ac6f14f852b8713dc)
 - Bugfix: Opening the avatar of a user from a usercard in the browser now opens the correct URL (c8a096c868864e0a51911640534d3e3283298bda)
 - Bugfix: If a user never set their 7TV avatar, the usercard will no longer show a button to switch between Twitch and 7TV (519a2c3174a96fc19cf59a87005dda07c344b04a)
 - Bugfix: Fixed mentions becoming unclickable when a user updated/announced their personal emotes (7ed952b61073e3081ab1377d1429f554f71b6a07)
-- Minor: Added 7TV Discord link to about section and changed the commit link to the correct location (2b17eae8259142fc8688a846c898d5fe6c5a878f)
 
 ## 7.5.2-beta.1
 

--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -6,6 +6,7 @@
 - Bugfix: Opening the avatar of a user from a usercard in the browser now opens the correct URL (c8a096c868864e0a51911640534d3e3283298bda)
 - Bugfix: If a user never set their 7TV avatar, the usercard will no longer show a button to switch between Twitch and 7TV (519a2c3174a96fc19cf59a87005dda07c344b04a)
 - Bugfix: Fixed mentions becoming unclickable when a user updated/announced their personal emotes (7ed952b61073e3081ab1377d1429f554f71b6a07)
+- Minor: Added 7TV Discord link to about section and changed the commit link to the correct location (2b17eae8259142fc8688a846c898d5fe6c5a878f)
 
 ## 7.5.2-beta.1
 

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -14,8 +14,7 @@ inline constexpr QStringView LINK_CHATTERINO_DISCORD =
     u"https://discord.gg/7Y5AYhAK4z";
 inline constexpr QStringView LINK_CHATTERINO_SOURCE =
     u"https://github.com/Chatterino/chatterino2";
-inline constexpr QStringView LINK_SEVENTV_DISCORD =
-    u"https://discord.gg/7TV";
+inline constexpr QStringView LINK_SEVENTV_DISCORD = u"https://discord.gg/7TV";
 
 inline constexpr QStringView TWITCH_PLAYER_URL =
     u"https://player.twitch.tv/?channel=%1&parent=twitch.tv";

--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -14,6 +14,8 @@ inline constexpr QStringView LINK_CHATTERINO_DISCORD =
     u"https://discord.gg/7Y5AYhAK4z";
 inline constexpr QStringView LINK_CHATTERINO_SOURCE =
     u"https://github.com/Chatterino/chatterino2";
+inline constexpr QStringView LINK_SEVENTV_DISCORD =
+    u"https://discord.gg/7TV";
 
 inline constexpr QStringView TWITCH_PLAYER_URL =
     u"https://player.twitch.tv/?channel=%1&parent=twitch.tv";

--- a/src/common/Version.cpp
+++ b/src/common/Version.cpp
@@ -155,7 +155,7 @@ void Version::generateBuildString()
     // Add commit information
     s +=
         QString(
-            R"( (commit <a href="https://github.com/Chatterino/chatterino2/commit/%1">%1</a>)")
+            R"( (commit <a href="https://github.com/SevenTV/chatterino7/commit/%1">%1</a>)")
             .arg(this->commitHash());
     if (this->isModified())
     {

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -68,6 +68,7 @@ AboutPage::AboutPage()
             l.emplace<QLabel>("Chatterino Wiki can be found <a href=\"" % LINK_CHATTERINO_WIKI % "\">here</a>")->setOpenExternalLinks(true);
             l.emplace<QLabel>("All about Chatterino's <a href=\"" % LINK_CHATTERINO_FEATURES % "\">features</a>")->setOpenExternalLinks(true);
             l.emplace<QLabel>("Join the official Chatterino <a href=\"" % LINK_CHATTERINO_DISCORD % "\">Discord</a>")->setOpenExternalLinks(true);
+			l.emplace<QLabel>("Join the official 7TV <a href=\"" % LINK_SEVENTV_DISCORD % "\">Discord</a>")->setOpenExternalLinks(true);
             // clang-format on
         }
 

--- a/src/widgets/settingspages/AboutPage.cpp
+++ b/src/widgets/settingspages/AboutPage.cpp
@@ -68,7 +68,7 @@ AboutPage::AboutPage()
             l.emplace<QLabel>("Chatterino Wiki can be found <a href=\"" % LINK_CHATTERINO_WIKI % "\">here</a>")->setOpenExternalLinks(true);
             l.emplace<QLabel>("All about Chatterino's <a href=\"" % LINK_CHATTERINO_FEATURES % "\">features</a>")->setOpenExternalLinks(true);
             l.emplace<QLabel>("Join the official Chatterino <a href=\"" % LINK_CHATTERINO_DISCORD % "\">Discord</a>")->setOpenExternalLinks(true);
-			l.emplace<QLabel>("Join the official 7TV <a href=\"" % LINK_SEVENTV_DISCORD % "\">Discord</a>")->setOpenExternalLinks(true);
+            l.emplace<QLabel>("Join the official 7TV <a href=\"" % LINK_SEVENTV_DISCORD % "\">Discord</a>")->setOpenExternalLinks(true);
             // clang-format on
         }
 


### PR DESCRIPTION
Added 7TV Official Discord Page
Changed the Version to link to the correct branch in SevenTVs repo instead of Chatterinos repo

Before: 
![image](https://github.com/user-attachments/assets/59b360e9-1ebc-40d8-a19a-c5e9418afb6b)

After (tested in my own nightly build):
![image](https://github.com/user-attachments/assets/1e3172e5-675a-4f46-904b-8941752b90ce)
