### PR TITLE
fix: treat any stops with lower position as hard stops

### DIFF
--- a/src/providers/seventv/SeventvPaints.cpp
+++ b/src/providers/seventv/SeventvPaints.cpp
@@ -56,9 +56,9 @@ QGradientStops parsePaintStops(const QJsonArray &stops)
         // Setting a different color at the same position twice just overwrites
         // the previous color. So we have to shift the second point slightly
         // ahead, simulating an actual hard edge
-        if (position == lastStop)
+        if (position <= lastStop)
         {
-            position += 0.0000001;
+            position = lastStop + 0.0000001;
         }
 
         lastStop = position;


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
CSS treats any stops that have a lower or equal position as the last as hard stops, so let's do the same.
The paint in question had stops like "0%, 10%, 0%, 20%, 0% 30%" and so on.

Fixes #330 (I'll add an entry later).
