### PR TITLE
ci(macos): update x86_64 bottle

### DIFF
--- a/.CI/SetupHomebrewDeps.sh
+++ b/.CI/SetupHomebrewDeps.sh
@@ -71,8 +71,8 @@ brew install "$@"
 echo "Installing x86_64 dependencies"
 for dep in "$@"
 do
-    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" fetch --force --bottle-tag=ventura "$dep"
-    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install $(arch -x86_64 "$x86_64_homebrew_dir/bin/brew" --cache --bottle-tag=ventura "$dep")
+    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" fetch --force --bottle-tag=x86_64_sonoma "$dep"
+    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install $(arch -x86_64 "$x86_64_homebrew_dir/bin/brew" --cache --bottle-tag=x86_64_sonoma "$dep")
 done
 
 echo "Relinking boost libraries"

--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -3,6 +3,7 @@
 ## Unversioned
 
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
+- Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)
 
 ## 7.5.4
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Ventura was EOL'd 1 month ago.