### PR TITLE
fix(macos): Install x86 homebrew in regular location

### DIFF
--- a/.CI/SetupHomebrewDeps.sh
+++ b/.CI/SetupHomebrewDeps.sh
@@ -9,7 +9,7 @@ x86_64_homebrew_dir="/opt/homebrew-x86_64"
  # Directory where we place the finished universal library
 universal_lib_dir="/opt/universal-lib"
 
-export HOMEBREW_DEVELOPER=1
+# export HOMEBREW_DEVELOPER=1
 
 # args: path-to-library (in homebrew dir)
 c2-make-universal-dylib() {
@@ -66,9 +66,11 @@ sudo curl -L https://github.com/Homebrew/brew/tarball/master | sudo tar xz --str
 sudo chown -R $USER "$x86_64_homebrew_dir"
 
 echo "Installing ARM dependencies"
+brew update
 brew install "$@"
 
 echo "Installing x86_64 dependencies"
+arch -x86_64 "$x86_64_homebrew_dir/bin/brew" update
 for dep in "$@"
 do
     arch -x86_64 "$x86_64_homebrew_dir/bin/brew" fetch --force --bottle-tag=x86_64_sonoma "$dep"

--- a/.CI/SetupHomebrewDeps.sh
+++ b/.CI/SetupHomebrewDeps.sh
@@ -73,8 +73,9 @@ echo "Installing x86_64 dependencies"
 arch -x86_64 "$x86_64_homebrew_dir/bin/brew" update
 for dep in "$@"
 do
-    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" fetch --force --bottle-tag=x86_64_sonoma "$dep"
-    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install $(arch -x86_64 "$x86_64_homebrew_dir/bin/brew" --cache --bottle-tag=x86_64_sonoma "$dep")
+    # arch -x86_64 "$x86_64_homebrew_dir/bin/brew" fetch --force --bottle-tag=x86_64_sonoma "$dep"
+    # arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install $(arch -x86_64 "$x86_64_homebrew_dir/bin/brew" --cache --bottle-tag=x86_64_sonoma "$dep")
+    arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install "$dep"
 done
 
 echo "Relinking boost libraries"

--- a/.CI/SetupHomebrewDeps.sh
+++ b/.CI/SetupHomebrewDeps.sh
@@ -5,7 +5,7 @@ set -ex
 # Prefix for where to find the ARM64 library
 arm64_homebrew_dir="/opt/homebrew"
 # Prefix for where to find the x86 library
-x86_64_homebrew_dir="/opt/homebrew-x86_64"
+x86_64_homebrew_dir="/usr/local"
  # Directory where we place the finished universal library
 universal_lib_dir="/opt/universal-lib"
 
@@ -62,8 +62,8 @@ sudo mkdir "$universal_lib_dir"
 sudo chown -R $USER "$universal_lib_dir"
 
 echo "Installing x86_64 brew"
-sudo curl -L https://github.com/Homebrew/brew/tarball/master | sudo tar xz --strip 1 -C "$x86_64_homebrew_dir"
-sudo chown -R $USER "$x86_64_homebrew_dir"
+arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# sudo chown -R $USER "$x86_64_homebrew_dir"
 
 echo "Installing ARM dependencies"
 brew update

--- a/.CI/SetupHomebrewDeps.sh
+++ b/.CI/SetupHomebrewDeps.sh
@@ -56,7 +56,7 @@ c2-make-universal-dylib() {
     ln -v -s "${_universal_lib}" "${_override_lib}"
 }
 
-sudo mkdir "$x86_64_homebrew_dir"
+# sudo mkdir "$x86_64_homebrew_dir"
 sudo mkdir "$universal_lib_dir"
 
 sudo chown -R $USER "$universal_lib_dir"

--- a/.CI/SetupHomebrewDeps.sh
+++ b/.CI/SetupHomebrewDeps.sh
@@ -63,7 +63,6 @@ sudo chown -R $USER "$universal_lib_dir"
 
 echo "Installing x86_64 brew"
 arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-# sudo chown -R $USER "$x86_64_homebrew_dir"
 
 echo "Installing ARM dependencies"
 brew update
@@ -73,8 +72,6 @@ echo "Installing x86_64 dependencies"
 arch -x86_64 "$x86_64_homebrew_dir/bin/brew" update
 for dep in "$@"
 do
-    # arch -x86_64 "$x86_64_homebrew_dir/bin/brew" fetch --force --bottle-tag=x86_64_sonoma "$dep"
-    # arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install $(arch -x86_64 "$x86_64_homebrew_dir/bin/brew" --cache --bottle-tag=x86_64_sonoma "$dep")
     arch -x86_64 "$x86_64_homebrew_dir/bin/brew" install "$dep"
 done
 


### PR DESCRIPTION
<!--
    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->
Before, we installed the x86 homebrew in `/opt/homebrew-x86_64`. If we install OpenSSL there, we'd need to rebuild, as it requires homebrew to be installed in `/usr/local`.