### PR TITLE
Update channelAuthority to include lead_moderator badge

### DIFF
--- a/src/providers/twitch/TwitchBadge.cpp
+++ b/src/providers/twitch/TwitchBadge.cpp
@@ -8,7 +8,7 @@ namespace chatterino {
 // vanity flag is left out on purpose as it is our default flag
 const QSet<QString> globalAuthority{"staff", "admin", "global_mod"};
 const QSet<QString> predictions{"predictions"};
-const QSet<QString> channelAuthority{"moderator", "vip", "broadcaster"};
+const QSet<QString> channelAuthority{"lead_moderator", "moderator", "vip", "broadcaster"};
 const QSet<QString> subBadges{"subscriber", "founder"};
 
 Badge::Badge(QString key, QString value)


### PR DESCRIPTION
New `lead_moderator` badge is hidden when you hide vanity badges, so added it to `channelAuthority` set.