### PR TITLE
fix(kick): set current username on login

### DIFF
--- a/src/widgets/dialogs/KickLoginPage.cpp
+++ b/src/widgets/dialogs/KickLoginPage.cpp
@@ -232,7 +232,7 @@ private:
                                      .toArray()
                                      .at(0)
                                      .toObject();
-                KickAccountData{
+                KickAccountData data{
                     .username = obj["name"].toString(),
                     .userID =
                         static_cast<uint64_t>(obj["user_id"_L1].toInteger()),
@@ -241,9 +241,10 @@ private:
                     .authToken = tokenData["access_token"_L1].toString(),
                     .refreshToken = tokenData["refresh_token"_L1].toString(),
                     .expiresAt = expiresAt,
-                }
-                    .save();
+                };
+                data.save();
                 getApp()->getAccounts()->kick.reloadUsers();
+                getApp()->getAccounts()->kick.currentUsername = data.username;
                 this->accept();
                 this->close();
             })


### PR DESCRIPTION
Was a bit confusing that the current user isn't set when you log in (see linked issue).

Fixes #366.
