### PR TITLE
feat(updater): ignore major version when comparing 7.x.x to 2.y.y

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -6,6 +6,7 @@
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)
+- Dev: Preemptively treat version comparisons between `7.x.x` and `2.y.y` as upgrades (#372)
 
 ## 7.5.4
 

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -83,6 +83,14 @@ bool Updates::isDowngradeOf(const QString &online, const QString &current)
         return false;
     }
 
+    // TODO: remove once chatterino7's major version switches from `7` to `2`
+    if (currentVersion.major == 7 && onlineVersion.major == 2)
+    {
+        currentVersion = {2, onlineVersion.minor, onlineVersion.patch,
+                          onlineVersion.prerelease_type,
+                          onlineVersion.prerelease_number};
+    }
+
     return onlineVersion < currentVersion;
 }
 

--- a/src/singletons/Updates.cpp
+++ b/src/singletons/Updates.cpp
@@ -86,9 +86,9 @@ bool Updates::isDowngradeOf(const QString &online, const QString &current)
     // TODO: remove once chatterino7's major version switches from `7` to `2`
     if (currentVersion.major == 7 && onlineVersion.major == 2)
     {
-        currentVersion = {2, onlineVersion.minor, onlineVersion.patch,
-                          onlineVersion.prerelease_type,
-                          onlineVersion.prerelease_number};
+        currentVersion = {2, currentVersion.minor, currentVersion.patch,
+                          currentVersion.prerelease_type,
+                          currentVersion.prerelease_number};
     }
 
     return onlineVersion < currentVersion;


### PR DESCRIPTION
This PR aims to allow treating version comparisons going from `7.x.x` to `2.y.y` as an upgrade. This will help support the major version change, whenever that happens.

Relates to #323.