### PR TITLE
feat(kick): track room modes

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)

--- a/src/providers/kick/KickApi.cpp
+++ b/src/providers/kick/KickApi.cpp
@@ -136,7 +136,21 @@ KickPrivateChatroomInfo::KickPrivateChatroomInfo(BoostJsonObject obj)
     : roomID(obj["id"].toUint64())
     , createdAt(QDateTime::fromString(obj["created_at"].toQString(),
                                       Qt::ISODateWithMs))
+    , subscribersMode(obj["subscribers_mode"].toBool())
+    , emotesMode(obj["emotes_mode"].toBool())
 {
+    bool slowMode = obj["slow_mode"].toBool();
+    if (slowMode)
+    {
+        this->slowModeDuration =
+            std::chrono::seconds{obj["message_interval"].toInt64()};
+    }
+    bool followersMode = obj["followers_mode"].toBool();
+    if (followersMode)
+    {
+        this->followersModeDuration =
+            std::chrono::minutes{obj["following_min_duration"].toInt64()};
+    }
 }
 
 KickPrivateChannelInfo::KickPrivateChannelInfo(BoostJsonObject obj)

--- a/src/providers/kick/KickApi.hpp
+++ b/src/providers/kick/KickApi.hpp
@@ -5,6 +5,7 @@
 #include <QDateTime>
 #include <QString>
 
+#include <chrono>
 #include <cstdint>
 #include <functional>
 #include <span>
@@ -29,6 +30,10 @@ struct KickPrivateChatroomInfo {
 
     uint64_t roomID = 0;
     QDateTime createdAt;
+    bool subscribersMode = false;
+    bool emotesMode = false;
+    std::optional<std::chrono::seconds> slowModeDuration;
+    std::optional<std::chrono::minutes> followersModeDuration;
 };
 
 struct KickPrivateChannelInfo {

--- a/src/providers/kick/KickChannel.cpp
+++ b/src/providers/kick/KickChannel.cpp
@@ -408,6 +408,21 @@ const KickChannel::StreamData &KickChannel::streamData() const
     return this->streamData_;
 }
 
+const KickChannel::RoomModes &KickChannel::roomModes() const
+{
+    return this->roomModes_;
+}
+
+void KickChannel::updateRoomModes(const RoomModes &modes)
+{
+    if (modes == this->roomModes_)
+    {
+        return;
+    }
+    this->roomModes_ = modes;
+    this->roomModesChanged.invoke();
+}
+
 void KickChannel::resolveChannelInfo()
 {
     auto weak = this->weakFromThis();
@@ -442,6 +457,13 @@ void KickChannel::resolveChannelInfo()
             {
                 self->displayNameChanged.invoke();
             }
+
+            self->updateRoomModes(RoomModes{
+                .subscribersMode = res->chatroom.subscribersMode,
+                .emotesMode = res->chatroom.emotesMode,
+                .slowModeDuration = res->chatroom.slowModeDuration,
+                .followersModeDuration = res->chatroom.followersModeDuration,
+            });
         });
 }
 

--- a/src/providers/kick/KickChannel.hpp
+++ b/src/providers/kick/KickChannel.hpp
@@ -38,6 +38,15 @@ public:
         uint64_t channelID = 0;
     };
 
+    struct RoomModes {
+        bool subscribersMode = false;
+        bool emotesMode = false;
+        std::optional<std::chrono::seconds> slowModeDuration;
+        std::optional<std::chrono::minutes> followersModeDuration;
+
+        auto operator<=>(const RoomModes &other) const = default;
+    };
+
     KickChannel(const QString &name);
     ~KickChannel() override;
 
@@ -123,6 +132,9 @@ public:
 
     pajlada::Signals::NoArgSignal userIDChanged;
     pajlada::Signals::NoArgSignal userStateChanged;
+
+    const RoomModes &roomModes() const;
+    void updateRoomModes(const RoomModes &modes);
     pajlada::Signals::NoArgSignal roomModesChanged;
 
     friend QDebug operator<<(QDebug dbg, const KickChannel &chan);
@@ -175,6 +187,8 @@ private:
     std::queue<std::chrono::steady_clock::time_point> lastMessageTimestamps_;
     std::chrono::steady_clock::time_point lastMessageSpeedErrorTs_;
     std::chrono::steady_clock::time_point lastMessageAmountErrorTs_;
+
+    RoomModes roomModes_;
 
     bool isMod_ = false;
     bool isVip_ = false;

--- a/src/providers/kick/KickChatServer.hpp
+++ b/src/providers/kick/KickChatServer.hpp
@@ -80,6 +80,7 @@ private:
     void onGiftedSubscriptionEvent(KickChannel *channel, BoostJsonObject data);
     void onRewardRedeemedEvent(KickChannel *channel, BoostJsonObject data);
     void onKicksGiftedEvent(KickChannel *channel, BoostJsonObject data);
+    void onChatroomUpdatedEvent(KickChannel *channel, BoostJsonObject data);
 
     void onKnownIgnoredMessage(KickChannel *channel, BoostJsonObject data);
 

--- a/src/providers/kick/KickMessageBuilder.cpp
+++ b/src/providers/kick/KickMessageBuilder.cpp
@@ -879,6 +879,38 @@ MessagePtrMut KickMessageBuilder::makeKicksGiftedMessage(KickChannel *channel,
     return builder.release();
 }
 
+MessagePtrMut KickMessageBuilder::makeRoomModeMessage(
+    KickChannel *channel, const QString &mode, bool enabled,
+    std::optional<std::chrono::seconds> duration)
+{
+    KickMessageBuilder builder(systemMessage, channel,
+                               QDateTime::currentDateTime());
+    builder->flags.set(MessageFlag::ModerationAction);
+    QString text;
+
+    QString enabledText = enabled ? u"enabled"_s : u"disabled"_s;
+
+    builder.emplaceSystemTextAndUpdate(mode, text);
+    builder.emplaceSystemTextAndUpdate(u"mode"_s, text);
+
+    if (duration && duration->count() > 0)
+    {
+        builder.emplaceSystemTextAndUpdate(u'(' % formatTime(*duration) % u')',
+                                           text);
+    }
+
+    builder.emplaceSystemTextAndUpdate(u"has been"_s, text);
+    builder.emplaceSystemTextAndUpdate(enabledText, text);
+
+    text.removeLast();
+    builder->elements.back()->setTrailingSpace(false);
+    builder.emplaceSystemTextAndUpdate(u"."_s, text);
+
+    builder->messageText = text;
+    builder->searchText = text;
+    return builder.release();
+}
+
 void KickMessageBuilder::appendChannelName()
 {
     QString channelName('#' + this->channel()->getName());

--- a/src/providers/kick/KickMessageBuilder.hpp
+++ b/src/providers/kick/KickMessageBuilder.hpp
@@ -45,6 +45,10 @@ public:
     static MessagePtrMut makeKicksGiftedMessage(KickChannel *channel,
                                                 BoostJsonObject data);
 
+    static MessagePtrMut makeRoomModeMessage(
+        KickChannel *channel, const QString &mode, bool enabled,
+        std::optional<std::chrono::seconds> duration);
+
     KickChannel *channel() const
     {
         return this->channel_;

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -58,33 +58,32 @@ constexpr const int ADD_SPLIT_BUTTON_WIDTH = 16;
 // 5 minutes
 constexpr const qint64 THUMBNAIL_MAX_AGE_MS = 5LL * 60 * 1000;
 
-auto formatRoomModeUnclean(
-    const SharedAccessGuard<const TwitchChannel::RoomModes> &modes) -> QString
+auto formatRoomModeUnclean(const TwitchChannel::RoomModes &modes) -> QString
 {
     QString text;
 
-    if (modes->r9k)
+    if (modes.r9k)
     {
         text += "r9k, ";
     }
-    if (modes->slowMode > 0)
+    if (modes.slowMode > 0)
     {
-        text += QString("slow(%1), ").arg(localizeNumbers(modes->slowMode));
+        text += QString("slow(%1), ").arg(localizeNumbers(modes.slowMode));
     }
-    if (modes->emoteOnly)
+    if (modes.emoteOnly)
     {
         text += "emote, ";
     }
-    if (modes->submode)
+    if (modes.submode)
     {
         text += "sub, ";
     }
-    if (modes->followerOnly != -1)
+    if (modes.followerOnly != -1)
     {
-        if (modes->followerOnly != 0)
+        if (modes.followerOnly != 0)
         {
             text += QString("follow(%1m), ")
-                        .arg(localizeNumbers(modes->followerOnly));
+                        .arg(localizeNumbers(modes.followerOnly));
         }
         else
         {
@@ -93,6 +92,26 @@ auto formatRoomModeUnclean(
     }
 
     return text;
+}
+
+QString formatRoomModeUnclean(const KickChannel::RoomModes &modes)
+{
+    TwitchChannel::RoomModes twitch{
+        .submode = modes.subscribersMode,
+        .r9k = false,
+        .emoteOnly = modes.emotesMode,
+        .followerOnly = -1,
+        .slowMode = 0,
+    };
+    if (modes.followersModeDuration)
+    {
+        twitch.followerOnly = modes.followersModeDuration->count();
+    }
+    if (modes.slowModeDuration)
+    {
+        twitch.slowMode = static_cast<int>(modes.slowModeDuration->count());
+    }
+    return formatRoomModeUnclean(twitch);
 }
 
 void cleanRoomModeText(QString &text, bool hasModRights)
@@ -802,7 +821,7 @@ void SplitHeader::updateRoomModes()
         QString text;
         {
             auto roomModes = twitchChannel->accessRoomModes();
-            text = formatRoomModeUnclean(roomModes);
+            text = formatRoomModeUnclean(*roomModes);
 
             // Set menu action
             this->modeActionSetR9k->setChecked(roomModes->r9k);
@@ -827,6 +846,24 @@ void SplitHeader::updateRoomModes()
         }
 
         // Update the mode button menu actions
+    }
+    else if (auto *kc =
+                 dynamic_cast<KickChannel *>(this->split_->getChannel().get()))
+    {
+        this->modeButton_->setEnabled(false);
+
+        QString text = formatRoomModeUnclean(kc->roomModes());
+        cleanRoomModeText(text, false);
+
+        if (!text.isEmpty())
+        {
+            this->modeButton_->setText(text);
+            this->modeButton_->show();
+        }
+        else
+        {
+            this->modeButton_->hide();
+        }
     }
     else
     {

--- a/src/widgets/splits/SplitHeader.cpp
+++ b/src/widgets/splits/SplitHeader.cpp
@@ -105,7 +105,8 @@ QString formatRoomModeUnclean(const KickChannel::RoomModes &modes)
     };
     if (modes.followersModeDuration)
     {
-        twitch.followerOnly = modes.followersModeDuration->count();
+        twitch.followerOnly =
+            static_cast<int>(modes.followersModeDuration->count());
     }
     if (modes.slowModeDuration)
     {

--- a/tests/src/Plugins.cpp
+++ b/tests/src/Plugins.cpp
@@ -975,6 +975,7 @@ TEST_F(PluginTest, MessageElementFlag)
                          "EmojiText=0x1000000,"
                          "EmoteImage=0x10,"
                          "EmoteText=0x20,"
+                         "KickUsername=0x4000000000,"
                          "LowercaseLinks=0x20000000,"
                          "Mention=0x8000000,"
                          "Misc=0x1,"


### PR DESCRIPTION
Room modes were not tracked before - now they're shown in the split header.