### PR TITLE
fix(kick): spellchecking and trim login

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)

--- a/src/widgets/dialogs/KickLoginPage.cpp
+++ b/src/widgets/dialogs/KickLoginPage.cpp
@@ -275,9 +275,8 @@ KickLoginPage::KickLoginPage()
         "to authenticate without exposing the client secret or using an "
         "external server that would need to see <i>all</i> tokens of "
         "<i>all</i> users.<br>Because of this, Chatterino7 currently requires "
-        "users to provide their own application credentials. Unfortunately, "
-        "this requires you to enable 2FA.<br><br>Applications "
-        "can be created at <a "
+        "users to provide their own application credentials. "
+        "<br><br>Applications can be created at <a "
         "href=\"https://kick.com/settings/developer\">kick.com/settings/"
         "developer</a>. The following redirect URL <b>must</b> be specified: "
         "<b><code>" %

--- a/src/widgets/splits/InputHighlighter.hpp
+++ b/src/widgets/splits/InputHighlighter.hpp
@@ -16,6 +16,7 @@ namespace chatterino {
 
 class Channel;
 class TwitchChannel;
+class KickChannel;
 class SpellChecker;
 
 /// This highlights the text in the split input.
@@ -40,6 +41,7 @@ private:
     QTextCharFormat spellFmt;
 
     std::weak_ptr<TwitchChannel> channel;
+    std::weak_ptr<KickChannel> kickChannel;
 
     QRegularExpression wordRegex;
 };


### PR DESCRIPTION
- Spellchecking didn't account for Kick channels.
- The login page should be neutral.