### PR TITLE
feat(kick): Message wait timer and more

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)

--- a/src/providers/kick/KickChannel.cpp
+++ b/src/providers/kick/KickChannel.cpp
@@ -428,6 +428,17 @@ void KickChannel::updateRoomModes(const RoomModes &modes)
     this->roomModesChanged.invoke();
 }
 
+void KickChannel::messageRemovedFromStart(const MessagePtr &msg)
+{
+    if (msg->replyThread)
+    {
+        if (msg->replyThread->liveCount(msg) == 0)
+        {
+            this->threads_.erase(msg->replyThread->rootId());
+        }
+    }
+}
+
 void KickChannel::resolveChannelInfo()
 {
     auto weak = this->weakFromThis();

--- a/src/providers/kick/KickChannel.cpp
+++ b/src/providers/kick/KickChannel.cpp
@@ -23,6 +23,7 @@
 #include "providers/seventv/SeventvEventAPI.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Settings.hpp"
+#include "util/FormatTime.hpp"
 #include "util/Helpers.hpp"
 #include "util/PostToThread.hpp"
 
@@ -39,6 +40,12 @@ KickChannel::KickChannel(const QString &name)
     , seventvEmotes_(std::make_shared<const EmoteMap>())
 {
     this->setMentionFlag(MessageElementFlag::KickUsername);
+
+    this->sendWaitTimer_.setInterval(1s);
+    this->sendWaitTimer_.setSingleShot(false);
+    QObject::connect(&this->sendWaitTimer_, &QTimer::timeout, [this] {
+        this->emitSendWait();
+    });
 }
 
 KickChannel::~KickChannel()
@@ -275,11 +282,19 @@ void KickChannel::sendReply(const QString &message, const QString &replyToId)
     getKickApi()->sendMessage(
         this->userID(), prepared, replyToId,
         [weak = this->weakFromThis()](const auto &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
             if (res)
             {
+                if (self->roomModes_.slowModeDuration)
+                {
+                    self->setSendWait(*self->roomModes_.slowModeDuration);
+                }
                 return;  // message sent
             }
-            auto self = weak.lock();
             if (self)
             {
                 self->addSystemMessage(u"Failed to send message: " %
@@ -424,8 +439,34 @@ void KickChannel::updateRoomModes(const RoomModes &modes)
     {
         return;
     }
+
     this->roomModes_ = modes;
     this->roomModesChanged.invoke();
+
+    if (!modes.slowModeDuration || *modes.slowModeDuration == 0s)
+    {
+        this->setSendWait(0s);
+    }
+}
+
+void KickChannel::setSendWait(std::chrono::seconds waitTime)
+{
+    if (waitTime <= 0s)
+    {
+        if (this->sendWaitEnd_)
+        {
+            this->sendWaitEnd_ = std::nullopt;
+            this->emitSendWait();
+        }
+        return;
+    }
+
+    this->sendWaitEnd_ = std::chrono::steady_clock::now() + waitTime;
+    if (!this->sendWaitTimer_.isActive())
+    {
+        this->sendWaitTimer_.start();
+        this->emitSendWait();
+    }
 }
 
 void KickChannel::messageRemovedFromStart(const MessagePtr &msg)
@@ -804,6 +845,26 @@ bool KickChannel::tryReplaceLastSeventvAddOrRemove(MessageFlag op,
     this->replaceMessage(last, msg);
 
     return true;
+}
+
+void KickChannel::emitSendWait()
+{
+    auto now = std::chrono::steady_clock::now();
+    std::chrono::seconds remaining = 0s;
+    if (this->sendWaitEnd_)
+    {
+        remaining = std::chrono::duration_cast<std::chrono::seconds>(
+            *this->sendWaitEnd_ - now);
+    }
+    if (remaining <= 0s)
+    {
+        this->sendWaitTimer_.stop();
+        this->sendWaitUpdate.invoke({});
+    }
+    else
+    {
+        this->sendWaitUpdate.invoke(formatTime(remaining, 2));
+    }
 }
 
 QDebug operator<<(QDebug dbg, const KickChannel &chan)

--- a/src/providers/kick/KickChannel.hpp
+++ b/src/providers/kick/KickChannel.hpp
@@ -141,6 +141,9 @@ public:
 
     friend QDebug operator<<(QDebug dbg, const KickChannel &chan);
 
+protected:
+    void messageRemovedFromStart(const MessagePtr &msg) override;
+
 private:
     /// Message ID -> thread
     std::unordered_map<QString, std::weak_ptr<MessageThread>> threads_;

--- a/src/providers/kick/KickChannel.hpp
+++ b/src/providers/kick/KickChannel.hpp
@@ -139,6 +139,9 @@ public:
     void updateRoomModes(const RoomModes &modes);
     pajlada::Signals::NoArgSignal roomModesChanged;
 
+    pajlada::Signals::Signal<const QString &> sendWaitUpdate;
+    void setSendWait(std::chrono::seconds waitTime);
+
     friend QDebug operator<<(QDebug dbg, const KickChannel &chan);
 
 protected:
@@ -171,6 +174,8 @@ private:
     bool tryReplaceLastSeventvAddOrRemove(MessageFlag op, const QString &actor,
                                           const QString &emoteName);
 
+    void emitSendWait();
+
     // Kick usually calls this username
     QString displayName_;
     // The name in the URL (replaces non-alphanumeric characters with dashes)
@@ -192,6 +197,10 @@ private:
     std::queue<std::chrono::steady_clock::time_point> lastMessageTimestamps_;
     std::chrono::steady_clock::time_point lastMessageSpeedErrorTs_;
     std::chrono::steady_clock::time_point lastMessageAmountErrorTs_;
+
+    QTimer sendWaitTimer_;
+    // Timepoint at which the user can send messages again
+    std::optional<std::chrono::steady_clock::time_point> sendWaitEnd_;
 
     RoomModes roomModes_;
 

--- a/src/providers/seventv/SeventvPaints.cpp
+++ b/src/providers/seventv/SeventvPaints.cpp
@@ -195,7 +195,7 @@ void SeventvPaints::assignPaintToUser(const QString &paintID,
     bool changed = false;
     int64_t nAdded = 0;
     auto addToMap = [&](auto &map, const QString &username) {
-        auto it = map.find(twitchUserName.string);
+        auto it = map.find(username);
         if (it == map.end())
         {
             map.emplace(username, paintIt->second);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -884,6 +884,11 @@ void Split::setChannel(IndirectChannel newChannel)
         this->roomModeChangedConnection_ = kc->roomModesChanged.connect([this] {
             this->header_->updateRoomModes();
         });
+
+        this->channelSignalHolder_.managedConnect(
+            kc->sendWaitUpdate, [this](const QString &text) {
+                this->getInput().setSendWaitStatus(text);
+            });
     }
 
     this->indirectChannelChangedConnection_ =

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -320,6 +320,7 @@ void SplitInput::themeChangedEvent()
     palette.setColor(QPalette::WindowText, this->theme->splits.input.text);
 
     this->ui_.textEditLength->setPalette(palette);
+    this->ui_.sendWaitStatus->setPalette(palette);
 
     // Theme changed, reset current background color
     this->setBackgroundColor(this->theme->splits.input.background);
@@ -1446,8 +1447,10 @@ void SplitInput::updateFonts()
 
     // NOTE: We're using TimestampMedium here to get a font that uses the tnum font feature,
     // meaning numbers get equal width & don't bounce around while the user is typing.
-    this->ui_.textEditLength->setFont(
-        app->getFonts()->getFont(FontStyle::TimestampMedium, this->scale()));
+    auto tsMedium =
+        app->getFonts()->getFont(FontStyle::TimestampMedium, this->scale());
+    this->ui_.textEditLength->setFont(tsMedium);
+    this->ui_.sendWaitStatus->setFont(tsMedium);
     this->ui_.replyLabel->setFont(
         app->getFonts()->getFont(FontStyle::ChatMediumBold, this->scale()));
 }


### PR DESCRIPTION
- Adds support for the message wait timer
	- Fixes that timer not using the same style as the message length label (PR tbd)
- Fixes (weak) reply threads being held on for too long
- Fixes paints not assigning the correct Kick user