### PR TITLE
fix(kick): Improve account dialog but phrase it as optional

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)

--- a/src/widgets/dialogs/KickLoginPage.cpp
+++ b/src/widgets/dialogs/KickLoginPage.cpp
@@ -120,6 +120,8 @@ public:
 
         auto *root = new QVBoxLayout(this);
         root->addWidget(&this->statusLabel, 1, Qt::AlignCenter);
+        root->addWidget(new QLabel("This window will close automatically."), 1,
+                        Qt::AlignCenter);
 
         auto *urlButtons = new QWidget;
         auto *urlButtonLayout = new QHBoxLayout(urlButtons);
@@ -275,11 +277,11 @@ KickLoginPage::KickLoginPage()
         "like Chatterino "
         "to authenticate without exposing the client secret or using an "
         "external server that would need to see <i>all</i> tokens of "
-        "<i>all</i> users.<br>Because of this, Chatterino7 currently requires "
-        "users to provide their own application credentials. "
-        "<br><br>Applications can be created at <a "
+        "<i>all</i> users.<br>Because of this, the <b>experimental</b> Kick "
+        "login is intended for developers with application credentials. "
+        "<br><br>Developer applications can be found at <a "
         "href=\"https://kick.com/settings/developer\">kick.com/settings/"
-        "developer</a>. The following redirect URL <b>must</b> be specified: "
+        "developer</a>. The following redirect URL <b>must</b> be added: "
         "<b><code>" %
         REDIRECT_URL % "</code></b>");
     topLabel->setWordWrap(true);

--- a/src/widgets/dialogs/KickLoginPage.cpp
+++ b/src/widgets/dialogs/KickLoginPage.cpp
@@ -98,6 +98,7 @@ public:
         , statusLabel("Waiting...")
     {
         this->setAttribute(Qt::WA_DeleteOnClose);
+        this->setWindowTitle("Waiting...");
 
         QUrlQuery query{
             {"response_type", "code"},

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -760,7 +760,9 @@ void Split::updateInputPlaceholder()
         QString placeholderText = [&] {
             if (user->isAnonymous())
             {
-                return QStringLiteral("Log in to send messages...");
+                // FIXME: once we have a proper OAuth for Kick (device auth or similar),
+                // we can update this label to "Log in to send messages...".
+                return QString{};
             }
             return QString(u"Send message as " % user->username() % u"...");
         }();


### PR DESCRIPTION
This does two things in one PR:

- Add a window title to the account dialog and show a message that the popup closes automatically.
- Phrase the wording on the initial page as "this is for developers".
  Even though you can use this as a regular user, I don't feel comfortable instructing _every_ Chatterino7 user to create an application. That's not the point of these developer applications. The point is to have one developer application per "real" app (Chatterino) and have multiple users authenticate with one app. However, due to the restrictions of the Kick API, we can't do that. While I could say "no one can log in", I still feel like the login provides an overall benefit.