### PR TITLE
fix(kick): force custom operation for `DELETE` with body

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,7 @@ find_package(Qt${MAJOR_QT_VERSION} REQUIRED
 )
 
 find_package(Qt${MAJOR_QT_VERSION} COMPONENTS WidgetsPrivate)
+find_package(Qt${MAJOR_QT_VERSION} COMPONENTS NetworkPrivate)
 if(CHATTERINO_ALLOW_PRIVATE_QT_API)
     # Only exists since 6.10 and prints a warning regarding private headers
     find_package(Qt${MAJOR_QT_VERSION} COMPONENTS GuiPrivate)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -979,6 +979,7 @@ target_link_libraries(${LIBRARY_PROJECT}
         Qt${MAJOR_QT_VERSION}::WidgetsPrivate # for pixmap filters (paints)
         Qt${MAJOR_QT_VERSION}::Gui
         Qt${MAJOR_QT_VERSION}::Network
+        Qt${MAJOR_QT_VERSION}::NetworkPrivate # for DELETE with a body (Kick)
         Qt${MAJOR_QT_VERSION}::Svg
         Qt${MAJOR_QT_VERSION}::Concurrent
 

--- a/src/common/network/NetworkTask.cpp
+++ b/src/common/network/NetworkTask.cpp
@@ -17,6 +17,31 @@
 #include <QNetworkReply>
 #include <QtConcurrent>
 
+#ifndef signals
+#    define signals public  // the file uses signals: but we build without that
+#endif
+#include <private/qnetworkreplyhttpimpl_p.h>  // for QNetworkReplyHttpImplPrivate
+#undef signals
+
+namespace {
+
+/// For DELETE requests, Qt remaps the operation to `DeleteOperation`:
+/// https://github.com/qt/qtbase/blob/bc60fa052b6163bcf444dab027bd6c1e717c9845/src/network/access/qnetworkreplyhttpimpl.cpp#L141-L161
+/// If we specified a body on the request. That will get dropped, because
+/// `DeleteOperation` has a special handler that won't use the body.
+void forceCustomOperation(QNetworkReply *reply)
+{
+    auto *d = dynamic_cast<QNetworkReplyHttpImplPrivate *>(
+        QObjectPrivate::get(reply));
+    if (!d)
+    {
+        return;  // not an HTTP request?
+    }
+    d->operation = QNetworkAccessManager::CustomOperation;
+}
+
+}  // namespace
+
 namespace chatterino::network::detail {
 
 NetworkTask::NetworkTask(std::shared_ptr<NetworkData> &&data)
@@ -87,9 +112,21 @@ QNetworkReply *NetworkTask::createReply()
         case NetworkRequestType::Get:
             return accessManager->get(request);
 
-        case NetworkRequestType::Delete:
-            return NetworkManager::accessManager->sendCustomRequest(
-                request, "DELETE", data->payload);
+        case NetworkRequestType::Delete: {
+            if (data->payload.isEmpty())
+            {
+                return accessManager->deleteResource(request);
+            }
+
+            auto *reply = accessManager->sendCustomRequest(request, "DELETE",
+                                                           data->payload);
+            if (!reply)
+            {
+                return reply;
+            }
+            forceCustomOperation(reply);
+            return reply;
+        }
 
         case NetworkRequestType::Put:
             if (data->multiPartPayload)

--- a/src/common/network/NetworkTask.cpp
+++ b/src/common/network/NetworkTask.cpp
@@ -31,8 +31,9 @@ namespace {
 /// `DeleteOperation` has a special handler that won't use the body.
 void forceCustomOperation(QNetworkReply *reply)
 {
-    auto *d = dynamic_cast<QNetworkReplyHttpImplPrivate *>(
-        QObjectPrivate::get(reply));
+    // We can't use dynamic_cast here, since some Qt builds are without RTTI.
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-static-cast-downcast)
+    auto *d = static_cast<QNetworkReplyPrivate *>(QObjectPrivate::get(reply));
     if (!d)
     {
         return;  // not an HTTP request?


### PR DESCRIPTION
When unbanning a user, we need to send a `DELETE` request with a body. When just using `sendCustomRequest`, Qt will remap the method to `DeleteOperation` and not send the body. We can fix this by reverting the mapping and setting `CustomOperation`, because the call to `_q_startOperation` is queued.

We have to mess with the private parts of QtNetwork here, so we now depend on `Qt6::NetworkPrivate`. Since we already depend on `Qt6::WidgetsPrivate`, this shouldn't be a huge issue. Most Linux distros bring in the whole qtbase as private if requested.