### PR TITLE
fix(seventv): support multiple connections to the same platform

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -4,6 +4,7 @@
 
 - Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
+- Bugfix: Fixed 7TV users with multiple connections to the same platform not having cosmetics applied on all connected accounts (#389)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)
 - Dev: Updated the macOS Homebrew bottles on x86_64 to Sonoma as Ventura was EOL'd 2025-Sep-15 (#336)
 - Dev: Preemptively treat version comparisons between `7.x.x` and `2.y.y` as upgrades (#372)

--- a/src/common/Channel.cpp
+++ b/src/common/Channel.cpp
@@ -470,7 +470,7 @@ void Channel::upsertPersonalSeventvEmotes(
     // added emotes are inserted where appropriate.
 
     assertInGuiThread();
-    auto snapshot = this->getMessageSnapshot();
+    auto snapshot = this->getMessageSnapshot(5);
     if (snapshot.empty())
     {
         return;

--- a/src/providers/seventv/SeventvEventAPI.hpp
+++ b/src/providers/seventv/SeventvEventAPI.hpp
@@ -20,6 +20,7 @@ struct EmoteAddDispatch;
 struct EmoteUpdateDispatch;
 struct EmoteRemoveDispatch;
 struct UserConnectionUpdateDispatch;
+struct PersonalEmoteSetAdded;
 }  // namespace seventv::eventapi
 
 class SeventvBadges;
@@ -38,19 +39,14 @@ public:
                         std::chrono::milliseconds(25000));
     ~SeventvEventAPI();
 
-    struct PersonalEmoteSetAdded {
-        QString twitchUserName;
-        QString kickUserName;
-        std::shared_ptr<const EmoteMap> emoteSet;
-    };
-
     struct {
         Signal<const seventv::eventapi::EmoteAddDispatch &> emoteAdded;
         Signal<const seventv::eventapi::EmoteUpdateDispatch &> emoteUpdated;
         Signal<const seventv::eventapi::EmoteRemoveDispatch &> emoteRemoved;
         Signal<const seventv::eventapi::UserConnectionUpdateDispatch &>
             userUpdated;
-        Signal<const PersonalEmoteSetAdded &> personalEmoteSetAdded;
+        Signal<const seventv::eventapi::PersonalEmoteSetAdded &>
+            personalEmoteSetAdded;
     } signals_;  // NOLINT(readability-identifier-naming)
 
     /**

--- a/src/providers/seventv/SeventvPaints.hpp
+++ b/src/providers/seventv/SeventvPaints.hpp
@@ -1,16 +1,22 @@
 #pragma once
 
-#include "common/Aliases.hpp"
 #include "providers/seventv/paints/Paint.hpp"
 
 #include <QJsonArray>
 #include <QString>
 
-#include <optional>
 #include <shared_mutex>
+#include <span>
 #include <unordered_map>
+#include <variant>
 
 namespace chatterino {
+
+namespace seventv::eventapi {
+struct TwitchUser;
+struct KickUser;
+using User = std::variant<TwitchUser, KickUser>;
+}  // namespace seventv::eventapi
 
 class SeventvPaints
 {
@@ -18,12 +24,10 @@ public:
     SeventvPaints();
 
     void addPaint(const QJsonObject &paintJson);
-    void assignPaintToUser(const QString &paintID,
-                           const UserName &twitchUserName,
-                           const UserName &kickUserName);
-    void clearPaintFromUser(const QString &paintID,
-                            const UserName &twitchUserName,
-                            const UserName &kickUserName);
+    void assignPaintToUsers(const QString &paintID,
+                            std::span<const seventv::eventapi::User> users);
+    void clearPaintFromUsers(const QString &paintID,
+                             std::span<const seventv::eventapi::User> users);
 
     std::shared_ptr<Paint> getPaint(const QString &userName, bool kick) const;
 

--- a/src/providers/seventv/SeventvPersonalEmotes.cpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.cpp
@@ -1,12 +1,15 @@
 #include "providers/seventv/SeventvPersonalEmotes.hpp"
 
+#include "providers/seventv/eventapi/Dispatch.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
 #include "singletons/Settings.hpp"
 #include "util/DebugCount.hpp"
+#include "util/Variant.hpp"
 
 #include <memory>
 #include <mutex>
 #include <optional>
+
 
 namespace chatterino {
 
@@ -33,34 +36,39 @@ void SeventvPersonalEmotes::createEmoteSet(const QString &id)
 }
 
 std::optional<std::shared_ptr<const EmoteMap>>
-    SeventvPersonalEmotes::assignUserToEmoteSet(const QString &emoteSetID,
-                                                const QString &userTwitchID,
-                                                uint64_t userKickID)
+    SeventvPersonalEmotes::assignUsersToEmoteSet(
+        const QString &emoteSetID,
+        std::span<const seventv::eventapi::User> users)
 {
     std::unique_lock<std::shared_mutex> lock(this->mutex_);
 
     int64_t additions = 0;
-    if (!userTwitchID.isEmpty())
-    {
-        auto &twitch = this->twitchEmoteSets_[userTwitchID];
-        // checking for one is enough because we always update both
-        // ...unless the user changed their connections
-        if (twitch.contains(emoteSetID))
+    auto tryAssign = [&](auto &list) {
+        if (list.contains(emoteSetID))
         {
+            return false;
+        }
+        list.append(emoteSetID);
+        additions++;
+        return true;
+    };
+    for (const auto &user : users)
+    {
+        bool changed =
+            std::visit(variant::Overloaded{
+                           [&](const seventv::eventapi::TwitchUser &u) {
+                               return tryAssign(this->twitchEmoteSets_[u.id]);
+                           },
+                           [&](const seventv::eventapi::KickUser &u) {
+                               return tryAssign(this->kickEmoteSets_[u.id]);
+                           }},
+                       user);
+        if (!changed)
+        {
+            // checking for one is enough because we always update all
+            // ...unless the user changed their connections
             return std::nullopt;
         }
-        twitch.append(emoteSetID);
-        additions++;
-    }
-    if (userKickID != 0)
-    {
-        auto &kick = this->kickEmoteSets_[userKickID];
-        if (kick.contains(emoteSetID))
-        {
-            return std::nullopt;
-        }
-        kick.append(emoteSetID);
-        additions++;
     }
 
     DebugCount::increase(DebugObject::SeventvPersonalEmoteAssignments,

--- a/src/providers/seventv/SeventvPersonalEmotes.cpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.cpp
@@ -10,7 +10,6 @@
 #include <mutex>
 #include <optional>
 
-
 namespace chatterino {
 
 using namespace Qt::Literals;

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -14,7 +14,6 @@
 #include <unordered_map>
 #include <variant>
 
-
 namespace chatterino {
 
 namespace seventv::eventapi {

--- a/src/providers/seventv/SeventvPersonalEmotes.hpp
+++ b/src/providers/seventv/SeventvPersonalEmotes.hpp
@@ -12,8 +12,16 @@
 #include <shared_mutex>
 #include <span>
 #include <unordered_map>
+#include <variant>
+
 
 namespace chatterino {
+
+namespace seventv::eventapi {
+struct TwitchUser;
+struct KickUser;
+using User = std::variant<TwitchUser, KickUser>;
+}  // namespace seventv::eventapi
 
 class SeventvPersonalEmotes
 {
@@ -23,9 +31,9 @@ public:
     void createEmoteSet(const QString &id);
 
     // Returns the emote-map of this set if it's new.
-    std::optional<std::shared_ptr<const EmoteMap>> assignUserToEmoteSet(
-        const QString &emoteSetID, const QString &userTwitchID,
-        uint64_t userKickID);
+    std::optional<std::shared_ptr<const EmoteMap>> assignUsersToEmoteSet(
+        const QString &emoteSetID,
+        std::span<const seventv::eventapi::User> users);
 
     void updateEmoteSet(const QString &id,
                         const seventv::eventapi::EmoteAddDispatch &dispatch);

--- a/src/providers/seventv/eventapi/Client.cpp
+++ b/src/providers/seventv/eventapi/Client.cpp
@@ -268,10 +268,7 @@ void Client::onEmoteSetUpdate(const Dispatch &dispatch)
         {
             qCDebug(chatterinoSeventvEventAPI) << "Flushed last emote set";
             this->manager_.signals_.personalEmoteSetAdded.invoke({
-                .twitchUserName =
-                    this->lastPersonalEmoteAssignment_->twitchUserName,
-                .kickUserName =
-                    this->lastPersonalEmoteAssignment_->kickUserName,
+                .connections = this->lastPersonalEmoteAssignment_->connections,
                 .emoteSet = *emoteSet,
             });
         }
@@ -353,25 +350,22 @@ void Client::onEntitlementCreate(
     switch (entitlement.kind)
     {
         case CosmeticKind::Badge: {
-            badges->assignBadgeToUser(entitlement.refID,
-                                      UserId{entitlement.twitchUserID},
-                                      entitlement.kickUserID);
+            badges->assignBadgeToUsers(entitlement.refID,
+                                       entitlement.connections);
         }
         break;
         case CosmeticKind::Paint: {
-            app->getSeventvPaints()->assignPaintToUser(
-                entitlement.refID, UserName{entitlement.twitchUserName},
-                UserName{entitlement.kickUserName});
+            app->getSeventvPaints()->assignPaintToUsers(
+                entitlement.refID, entitlement.connections);
         }
         break;
         case CosmeticKind::EmoteSet: {
             qCDebug(chatterinoSeventvEventAPI)
-                << "Assign user" << entitlement.twitchUserID << "to emote set"
-                << entitlement.refID;
+                << "Assign user" << entitlement.seventvUsername
+                << "to emote set" << entitlement.refID;
             if (auto set =
-                    app->getSeventvPersonalEmotes()->assignUserToEmoteSet(
-                        entitlement.refID, entitlement.twitchUserID,
-                        entitlement.kickUserID))
+                    app->getSeventvPersonalEmotes()->assignUsersToEmoteSet(
+                        entitlement.refID, entitlement.connections))
             {
                 if ((*set)->empty())
                 {
@@ -380,8 +374,7 @@ void Client::onEntitlementCreate(
                            "updates";
                     this->lastPersonalEmoteAssignment_ =
                         LastPersonalEmoteAssignment{
-                            .twitchUserName = entitlement.twitchUserName,
-                            .kickUserName = entitlement.kickUserName,
+                            .connections = entitlement.connections,
                             .emoteSetID = entitlement.refID,
                         };
                 }
@@ -389,8 +382,7 @@ void Client::onEntitlementCreate(
                 {
                     this->lastPersonalEmoteAssignment_ = std::nullopt;
                     this->manager_.signals_.personalEmoteSetAdded.invoke({
-                        .twitchUserName = entitlement.twitchUserName,
-                        .kickUserName = entitlement.kickUserName,
+                        .connections = entitlement.connections,
                         .emoteSet = *set,
                     });
                 }
@@ -415,15 +407,13 @@ void Client::onEntitlementDelete(
     switch (entitlement.kind)
     {
         case CosmeticKind::Badge: {
-            badges->clearBadgeFromUser(entitlement.refID,
-                                       UserId{entitlement.twitchUserID},
-                                       entitlement.kickUserID);
+            badges->clearBadgeFromUsers(entitlement.refID,
+                                        entitlement.connections);
         }
         break;
         case CosmeticKind::Paint: {
-            app->getSeventvPaints()->clearPaintFromUser(
-                entitlement.refID, UserName{entitlement.twitchUserName},
-                UserName{entitlement.kickUserName});
+            app->getSeventvPaints()->clearPaintFromUsers(
+                entitlement.refID, entitlement.connections);
         }
         break;
         default:

--- a/src/providers/seventv/eventapi/Client.hpp
+++ b/src/providers/seventv/eventapi/Client.hpp
@@ -12,7 +12,6 @@
 
 #include <QPointer>
 
-
 namespace chatterino {
 class SeventvEventAPI;
 class EmoteMap;

--- a/src/providers/seventv/eventapi/Client.hpp
+++ b/src/providers/seventv/eventapi/Client.hpp
@@ -7,9 +7,11 @@
 #include "providers/liveupdates/BasicPubSubClient.hpp"
 // this needs to be included for the specialization
 // of std::hash for Subscription
+#include "providers/seventv/eventapi/Dispatch.hpp"  // for Twitch/KickUser
 #include "providers/seventv/eventapi/Subscription.hpp"
 
 #include <QPointer>
+
 
 namespace chatterino {
 class SeventvEventAPI;
@@ -53,8 +55,7 @@ private:
     SeventvEventAPI &manager_;
 
     struct LastPersonalEmoteAssignment {
-        QString twitchUserName;
-        QString kickUserName;
+        QVarLengthArray<User, 1> connections;
         QString emoteSetID;
         std::shared_ptr<const EmoteMap> emoteSet;
     };

--- a/src/providers/seventv/eventapi/Dispatch.cpp
+++ b/src/providers/seventv/eventapi/Dispatch.cpp
@@ -122,7 +122,7 @@ TwitchUser::TwitchUser(const QJsonObject &connection)
 
 KickUser::KickUser(const QJsonObject &connection)
     : id(connection["id"_L1].toString().toULongLong())
-    , userName(connection["username"_L1].toString())
+    , userName(connection["username"_L1].toString().toLower())
 {
 }
 

--- a/src/providers/seventv/eventapi/Dispatch.cpp
+++ b/src/providers/seventv/eventapi/Dispatch.cpp
@@ -11,6 +11,8 @@
 
 #include <utility>
 
+using namespace Qt::Literals;
+
 namespace chatterino::seventv::eventapi {
 
 Dispatch::Dispatch(QJsonObject obj)
@@ -112,6 +114,18 @@ bool CosmeticCreateDispatch::validate() const
     return !this->data.empty() && this->kind != CosmeticKind::INVALID;
 }
 
+TwitchUser::TwitchUser(const QJsonObject &connection)
+    : id(connection["id"_L1].toString())
+    , userName(connection["username"_L1].toString())
+{
+}
+
+KickUser::KickUser(const QJsonObject &connection)
+    : id(connection["id"_L1].toString().toULongLong())
+    , userName(connection["username"_L1].toString())
+{
+}
+
 EntitlementCreateDeleteDispatch::EntitlementCreateDeleteDispatch(
     const Dispatch &dispatch)
 {
@@ -120,31 +134,27 @@ EntitlementCreateDeleteDispatch::EntitlementCreateDeleteDispatch(
     this->kind = qmagicenum::enumCast<CosmeticKind>(obj["kind"].toString())
                      .value_or(CosmeticKind::INVALID);
 
-    const auto userConnections = obj["user"]["connections"].toArray();
+    const auto userObj = obj["user"_L1].toObject();
+    this->seventvUsername = userObj["username"_L1].toString();
+    const auto userConnections = userObj["connections"_L1].toArray();
     for (const auto &connectionJson : userConnections)
     {
         const auto connection = connectionJson.toObject();
-        auto platform = connection["platform"].toString();
+        auto platform = connection["platform"_L1].toString();
         if (platform == u"TWITCH")
         {
-            this->twitchUserID = connection["id"].toString();
-            this->twitchUserName = connection["username"].toString();
+            this->connections.emplace_back(TwitchUser(connection));
         }
         else if (platform == u"KICK")
         {
-            this->kickUserID = connection["id"].toString().toULongLong();
-            this->kickUserName = connection["username"].toString().toLower();
+            this->connections.emplace_back(KickUser(connection));
         }
     }
 }
 
 bool EntitlementCreateDeleteDispatch::validate() const
 {
-    bool hasTwitch =
-        !this->twitchUserID.isEmpty() && !this->twitchUserName.isEmpty();
-    bool hasKick = this->kickUserID != 0 && !this->kickUserName.isEmpty();
-
-    return (hasTwitch || hasKick) && !this->refID.isEmpty() &&
+    return !this->connections.empty() && !this->refID.isEmpty() &&
            this->kind != CosmeticKind::INVALID;
 }
 

--- a/src/providers/seventv/eventapi/Dispatch.hpp
+++ b/src/providers/seventv/eventapi/Dispatch.hpp
@@ -12,6 +12,8 @@
 #include <QString>
 #include <QVarLengthArray>
 
+#include <span>
+
 namespace chatterino::seventv::eventapi {
 
 // https://github.com/SevenTV/EventAPI/tree/ca4ff15cc42b89560fa661a76c5849047763d334#message-payload

--- a/src/providers/seventv/eventapi/Dispatch.hpp
+++ b/src/providers/seventv/eventapi/Dispatch.hpp
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include "messages/Emote.hpp"
 #include "providers/seventv/eventapi/Subscription.hpp"
 #include "providers/seventv/SeventvCosmetics.hpp"
 
 #include <QJsonObject>
 #include <QString>
+#include <QVarLengthArray>
 
 namespace chatterino::seventv::eventapi {
 
@@ -81,12 +83,23 @@ struct CosmeticCreateDispatch {
     bool validate() const;
 };
 
+struct TwitchUser {
+    TwitchUser(const QJsonObject &connection);
+    QString id;
+    QString userName;
+};
+
+struct KickUser {
+    KickUser(const QJsonObject &connection);
+
+    uint64_t id;
+    QString userName;
+};
+using User = std::variant<TwitchUser, KickUser>;
+
 struct EntitlementCreateDeleteDispatch {
-    /** id of the user */
-    QString twitchUserID;
-    QString twitchUserName;
-    uint64_t kickUserID;
-    QString kickUserName;
+    QString seventvUsername;
+    QVarLengthArray<User, 1> connections;
     /** id of the entitlement */
     QString refID;
     CosmeticKind kind;
@@ -103,6 +116,11 @@ struct EmoteSetCreateDispatch {
     EmoteSetCreateDispatch(const QJsonObject &emoteSet);
 
     bool validate() const;
+};
+
+struct PersonalEmoteSetAdded {
+    std::span<const User> connections;
+    std::shared_ptr<const EmoteMap> emoteSet;
 };
 
 }  // namespace chatterino::seventv::eventapi

--- a/src/util/BadgeRegistry.cpp
+++ b/src/util/BadgeRegistry.cpp
@@ -5,10 +5,25 @@
 #include "util/BadgeRegistry.hpp"
 
 #include "messages/Emote.hpp"
+#include "providers/seventv/eventapi/Dispatch.hpp"
+#include "util/Variant.hpp"
 
 #include <QJsonArray>
 #include <QUrl>
 #include <QUrlQuery>
+
+namespace {
+
+void clearIfEquals(auto &map, auto &&key, const auto &expectedID)
+{
+    const auto it = map.find(std::forward<decltype(key)>(key));
+    if (it != map.end() && it->second->id.string == expectedID)
+    {
+        map.erase(it);
+    }
+}
+
+}  // namespace
 
 namespace chatterino {
 
@@ -37,45 +52,65 @@ std::optional<EmotePtr> BadgeRegistry::getKickBadge(uint64_t id) const
 }
 
 void BadgeRegistry::assignBadgeToUser(const QString &badgeID,
-                                      const UserId &userID, uint64_t kickUserID)
+                                      const UserId &userID)
 {
     const std::unique_lock lock(this->mutex_);
 
     const auto badgeIt = this->knownBadges_.find(badgeID);
     if (badgeIt != this->knownBadges_.end())
     {
-        if (!userID.string.isEmpty())
-        {
-            this->badgeMap_[userID.string] = badgeIt->second;
-        }
-        if (kickUserID != 0)
-        {
-            this->kickBadgeMap_[kickUserID] = badgeIt->second;
-        }
+        this->badgeMap_[userID.string] = badgeIt->second;
+    }
+}
+
+void BadgeRegistry::assignBadgeToUsers(
+    const QString &badgeID, std::span<const seventv::eventapi::User> users)
+{
+    const std::unique_lock lock(this->mutex_);
+
+    const auto badgeIt = this->knownBadges_.find(badgeID);
+    if (badgeIt == this->knownBadges_.end())
+    {
+        return;
+    }
+    for (const auto &user : users)
+    {
+        std::visit(variant::Overloaded{
+                       [&](const seventv::eventapi::TwitchUser &u) {
+                           this->badgeMap_[u.id] = badgeIt->second;
+                       },
+                       [&](const seventv::eventapi::KickUser &u) {
+                           this->kickBadgeMap_[u.id] = badgeIt->second;
+                       },
+                   },
+                   user);
     }
 }
 
 void BadgeRegistry::clearBadgeFromUser(const QString &badgeID,
-                                       const UserId &userID,
-                                       uint64_t kickUserID)
+                                       const UserId &userID)
 {
     const std::unique_lock lock(this->mutex_);
 
-    if (!userID.string.isEmpty())
+    clearIfEquals(this->badgeMap_, userID.string, badgeID);
+}
+
+void BadgeRegistry::clearBadgeFromUsers(
+    const QString &badgeID, std::span<const seventv::eventapi::User> users)
+{
+    const std::unique_lock lock(this->mutex_);
+
+    for (const auto &user : users)
     {
-        const auto it = this->badgeMap_.find(userID.string);
-        if (it != this->badgeMap_.end() && it->second->id.string == badgeID)
-        {
-            this->badgeMap_.erase(userID.string);
-        }
-    }
-    if (kickUserID != 0)
-    {
-        const auto it = this->kickBadgeMap_.find(kickUserID);
-        if (it != this->kickBadgeMap_.end() && it->second->id.string == badgeID)
-        {
-            this->kickBadgeMap_.erase(kickUserID);
-        }
+        std::visit(variant::Overloaded{
+                       [&](const seventv::eventapi::TwitchUser &u) {
+                           clearIfEquals(this->badgeMap_, u.id, badgeID);
+                       },
+                       [&](const seventv::eventapi::KickUser &u) {
+                           clearIfEquals(this->kickBadgeMap_, u.id, badgeID);
+                       },
+                   },
+                   user);
     }
 }
 

--- a/src/util/BadgeRegistry.hpp
+++ b/src/util/BadgeRegistry.hpp
@@ -9,8 +9,16 @@
 #include <QJsonObject>
 
 #include <shared_mutex>
+#include <span>
+#include <variant>
 
 namespace chatterino {
+
+namespace seventv::eventapi {
+struct TwitchUser;
+struct KickUser;
+using User = std::variant<TwitchUser, KickUser>;
+}  // namespace seventv::eventapi
 
 struct Emote;
 using EmotePtr = std::shared_ptr<const Emote>;
@@ -26,12 +34,16 @@ public:
     std::optional<EmotePtr> getKickBadge(uint64_t id) const;
 
     /// Assign the given badge to the user
-    void assignBadgeToUser(const QString &badgeID, const UserId &userID,
-                           uint64_t kickUserID = 0);
+    void assignBadgeToUser(const QString &badgeID, const UserId &userID);
+
+    void assignBadgeToUsers(const QString &badgeID,
+                            std::span<const seventv::eventapi::User> users);
 
     /// Remove the given badge from the user
-    void clearBadgeFromUser(const QString &badgeID, const UserId &userID,
-                            uint64_t kickUserID = 0);
+    void clearBadgeFromUser(const QString &badgeID, const UserId &userID);
+
+    void clearBadgeFromUsers(const QString &badgeID,
+                             std::span<const seventv::eventapi::User> users);
 
     /// Register a new known badge
     /// The json object will contain all information about the badge, like its ID & its images


### PR DESCRIPTION
One user can have multiple connections to the same platform. For example, a user might have multiple connections to Twitch.

This complicates the implementation a bit, because we need to handle all names. Especially for emote sets.