### PR TITLE
fix(kick): remove newlines from incoming messages

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388, #390)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Bugfix: Fixed 7TV users with multiple connections to the same platform not having cosmetics applied on all connected accounts (#389)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)

--- a/src/providers/kick/KickMessageBuilder.cpp
+++ b/src/providers/kick/KickMessageBuilder.cpp
@@ -461,7 +461,7 @@ std::pair<MessagePtrMut, HighlightAlert> KickMessageBuilder::makeChatMessage(
     KickChannel *kickChannel, BoostJsonObject data)
 {
     auto id = data["id"].toQString();
-    auto content = data["content"].toQString();
+    auto content = data["content"].toQString().simplified();
     auto createdAt = data["created_at"].toQString();
 
     auto sender = data["sender"].toObject();
@@ -663,7 +663,7 @@ MessagePtrMut KickMessageBuilder::makePinnedMessage(KickChannel *channel,
         {
             return existing->messageText;
         }
-        return jsonMessage["text"].toQString();
+        return jsonMessage["text"].toQString().simplified();
     }();
     auto limit = getSettings()->deletedMessageLengthLimit.getValue();
     if (limit > 0 && messageText.length() > limit)
@@ -717,7 +717,7 @@ std::tuple<MessagePtrMut, MessagePtrMut, HighlightAlert>
 
     auto months = data["months"].toUint64();
     auto username = data["username"].toQString();
-    auto customMessageText = data["custom_message"].toQString();
+    auto customMessageText = data["custom_message"].toQString().simplified();
     if (!customMessageText.isEmpty())
     {
         KickMessageBuilder builder(channel);
@@ -818,7 +818,7 @@ MessagePtrMut KickMessageBuilder::makeRewardRedeemedMessage(
 {
     const auto reward = data["reward_title"].toQString();
     const auto username = data["username"].toQString();
-    const auto userInput = data["user_input"].toQString();
+    const auto userInput = data["user_input"].toQString().simplified();
 
     KickMessageBuilder builder(channel, QDateTime::currentDateTime());
     builder->flags.set(MessageFlag::RedeemedChannelPointReward);
@@ -865,7 +865,7 @@ MessagePtrMut KickMessageBuilder::makeKicksGiftedMessage(KickChannel *channel,
     const auto gift = data["gift"].toObject();
     const auto giftName = gift["name"].toQString();
     const auto giftAmount = gift["amount"].toUint64();
-    const auto userInput = data["message"].toQString();
+    const auto userInput = data["message"].toQString().simplified();
 
     KickMessageBuilder builder(channel, QDateTime::currentDateTime());
     builder->flags.set(MessageFlag::RedeemedChannelPointReward);


### PR DESCRIPTION
For whatever reason, Kick messages can have newlines in them.