### PR TITLE
fix(kick): only show timeout buttons >= 1min

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388, #390)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388, #390, #391)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Bugfix: Fixed 7TV users with multiple connections to the same platform not having cosmetics applied on all connected accounts (#389)
 - Dev: Bumped Qt to 6.9.3 on Windows and macOS due to CVE-2025-10728 and CVE-2025-10729 (74077350da2d4cfff2ede0ce0ebb11654253b440)

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -104,6 +104,7 @@ private:
     // Pinned status is tracked in DraggablePopup::isPinned_.
     const bool closeAutomatically_;
 
+    class TimeoutWidget;
     struct {
         PixmapButton *avatarButton = nullptr;
         PixmapButton *localizedNameCopyButton = nullptr;
@@ -129,6 +130,8 @@ private:
 
         LabelButton *usercardLabel = nullptr;
         LabelButton *switchAvatars = nullptr;
+
+        TimeoutWidget *timeoutWidget = nullptr;
     } ui_;
 
     QMovie *seventvAvatar_ = nullptr;
@@ -148,8 +151,13 @@ private:
 
         pajlada::Signals::Signal<std::pair<Action, int>> buttonClicked;
 
+        void setMinTimeout(int minSecs);
+
     protected:
         void paintEvent(QPaintEvent *event) override;
+
+    private:
+        std::vector<std::pair<QWidget *, int>> timeoutButtons;
     };
 };
 


### PR DESCRIPTION
Kick doesn't support timeouts <1min, so hide these buttons.