### PR TITLE
ci: restrict GH token permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -460,6 +460,8 @@ jobs:
     needs: [build-ubuntu-docker, build-flatpak, build]
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/chatterino7')
+    permissions:
+      contents: write # create release
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/create-installer.yml
+++ b/.github/workflows/create-installer.yml
@@ -26,6 +26,9 @@ jobs:
     env:
       # same as in build.yml
       C2_ARCH: ${{ case(endsWith(matrix.os, '-arm'), 'arm', 'x86-64') }}
+    permissions:
+      # FIXME: this only needed for the nightly upload step (should split to another job)
+      contents: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -112,6 +115,9 @@ jobs:
   draft-release:
     runs-on: ubuntu-latest
     needs: [create-installer, check-release]
+    permissions:
+      # FIXME: this only needed for the last step (should split to another job)
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/post-clang-tidy-review.yml
+++ b/.github/workflows/post-clang-tidy-review.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     # Only when a build succeeds
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      pull-requests: write
 
     steps:
       - uses: ZedThree/clang-tidy-review/post@v0.23.0


### PR DESCRIPTION
Previously, the repository enabled the write permission by default (upstream still does so). We shouldn't do this and only enable write permissions if necessary. This is a step in that direction. The permissions could be scoped a bit more granular in the installer workflow. Since I plan to release a nightly installer and portable after this release, I'll wait with that.
