### PR TITLE
fix(kick): check token before refreshing

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,7 +2,7 @@
 
 ## Unversioned
 
-- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388, #390, #391)
+- Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388, #390, #391, #395)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Bugfix: Fixed 7TV users with multiple connections to the same platform not having cosmetics applied on all connected accounts (#389)
 - Bugfix: Fixed URL paints on mentions not being scaled correctly in high-dpi settings (57627edf4af49111bf5e0c1bc942ad4db3b85d96)

--- a/src/providers/kick/KickAccount.cpp
+++ b/src/providers/kick/KickAccount.cpp
@@ -156,52 +156,26 @@ void KickAccount::refreshIfNeeded()
     }
 
     auto now = QDateTime::currentDateTimeUtc() + CHECK_REFRESH_INTERVAL +
-               std::chrono::seconds{30};
+               std::chrono::seconds{60};
     if (now < this->expiresAt_)
     {
         return;
     }
+    qCDebug(chatterinoKick) << "Attempting to refresh" << this->username()
+                            << "expires:" << this->expiresAt_;
 
-    QUrlQuery payload{
-        {"refresh_token"_L1, this->refreshToken_},
-        {"client_id"_L1, this->clientID_},
-        {"client_secret"_L1, this->clientSecret_},
-        {"grant_type"_L1, "refresh_token"_L1},
-    };
-
-    auto weak = this->weak_from_this();
-    NetworkRequest(u"https://id.kick.com/oauth/token"_s,
-                   NetworkRequestType::Post)
-        .header("Content-Type", "application/x-www-form-urlencoded")
-        .payload(payload.toString(QUrl::FullyEncoded).toUtf8())
-        .onSuccess([weak](const NetworkResult &res) {
-            auto self = weak.lock();
-            if (!self)
-            {
-                return;
-            }
-
-            const auto json = res.parseJson();
-            self->authToken_ = json["access_token"_L1].toString();
-            self->refreshToken_ = json["refresh_token"_L1].toString();
-            auto expiresInSec =
-                std::clamp<qint64>(json["expires_in"_L1].toInteger(), 0,
-                                   std::numeric_limits<qint32>::max());
-            self->expiresAt_ =
-                QDateTime::currentDateTimeUtc().addSecs(expiresInSec);
-            self->save();
-            self->authUpdated.invoke();
-        })
-        .onError([weak](const NetworkResult &res) {
-            auto self = weak.lock();
-            if (!self)
-            {
-                return;
-            }
-            qCWarning(chatterinoKick) << "Failed to refresh" << self->username()
-                                      << "error:" << res.formatError();
-        })
-        .execute();
+    // Hack: check the current token first to ensure we're connected. Otherwise,
+    // we might miss the response.
+    // FIXME: queue re-check earlier
+    this->check([this](CheckResult res) {
+        if (res == CheckResult::NetworkError)
+        {
+            qCWarning(chatterinoKick)
+                << "Skipping refresh, because of network error";
+            return;
+        }
+        this->doRefresh();
+    });
 }
 
 void KickAccount::loadSeventvUser()
@@ -269,6 +243,93 @@ void KickAccount::loadSeventvUser()
             qCDebug(chatterinoSeventv)
                 << "Failed to load your 7TV user-id:" << result.formatError();
         });
+}
+
+void KickAccount::check(const std::function<void(CheckResult)> &cb)
+{
+    auto weak = this->weak_from_this();
+    NetworkRequest(u"https://id.kick.com/oauth/token/introspect"_s,
+                   NetworkRequestType::Post)
+        .timeout(10'000)
+        .onSuccess([cb, weak](const NetworkResult & /*res*/) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+            qCDebug(chatterinoKick)
+                << "[Refresh]: Successfully checked previous token";
+            cb(CheckResult::Valid);
+        })
+        .onError([weak, cb](const NetworkResult &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+            qCDebug(chatterinoKick)
+                << "[Refresh; Error] Network response:" << res.formatError();
+            auto status = res.status();
+            if (!status || *status < 100)
+            {
+                cb(CheckResult::NetworkError);
+                return;
+            }
+            if (*status == 401)
+            {
+                cb(CheckResult::Expired);
+                return;
+            }
+            cb(CheckResult::OtherHttp);
+        })
+        .execute();
+}
+
+void KickAccount::doRefresh()
+{
+    QUrlQuery payload{
+        {"refresh_token"_L1, this->refreshToken_},
+        {"client_id"_L1, this->clientID_},
+        {"client_secret"_L1, this->clientSecret_},
+        {"grant_type"_L1, "refresh_token"_L1},
+    };
+
+    auto weak = this->weak_from_this();
+    NetworkRequest(u"https://id.kick.com/oauth/token"_s,
+                   NetworkRequestType::Post)
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .payload(payload.toString(QUrl::FullyEncoded).toUtf8())
+        .timeout(20'000)
+        .onSuccess([weak](const NetworkResult &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+
+            const auto json = res.parseJson();
+            self->authToken_ = json["access_token"_L1].toString();
+            self->refreshToken_ = json["refresh_token"_L1].toString();
+            auto expiresInSec =
+                std::clamp<qint64>(json["expires_in"_L1].toInteger(), 0,
+                                   std::numeric_limits<qint32>::max());
+            self->expiresAt_ =
+                QDateTime::currentDateTimeUtc().addSecs(expiresInSec);
+            self->save();
+            self->authUpdated.invoke();
+            qCDebug(chatterinoKick)
+                << "[Refresh] Successful, next expiry:" << self->expiresAt_;
+        })
+        .onError([weak](const NetworkResult &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+            qCWarning(chatterinoKick) << "Failed to refresh" << self->username()
+                                      << "error:" << res.formatError();
+        })
+        .execute();
 }
 
 }  // namespace chatterino

--- a/src/providers/kick/KickAccount.hpp
+++ b/src/providers/kick/KickAccount.hpp
@@ -32,7 +32,7 @@ public:
     KickAccount(const KickAccountData &args);
     ~KickAccount() override;
 
-    constexpr static std::chrono::minutes CHECK_REFRESH_INTERVAL{5};
+    constexpr static std::chrono::minutes CHECK_REFRESH_INTERVAL{2};
 
     Q_DISABLE_COPY_MOVE(KickAccount);
 
@@ -83,6 +83,23 @@ public:
     pajlada::Signals::NoArgSignal authUpdated;
 
 private:
+    enum class CheckResult : uint8_t {
+        /// Returned 2xx
+        Valid,
+        /// 401 Unauthorized
+        ///
+        /// Expected if Chatterino just started. The tokens have an expiry of
+        /// 2h.
+        Expired,
+        /// Error code >=100, but not 401
+        OtherHttp,
+        /// A Qt error code <100
+        NetworkError,
+    };
+
+    void check(const std::function<void(CheckResult)> &cb);
+    void doRefresh();
+
     QString username_;
     uint64_t userID_ = 0;
     QString clientID_;


### PR DESCRIPTION
Sometimes the refreshing fails, so do a sanity check if we can connect at all. It doesn't prevent all errors, but at least some.