### PR TITLE
feat: extend usercard context menu

### DIFF
--- a/CHANGELOG.c7.md
+++ b/CHANGELOG.c7.md
@@ -2,6 +2,10 @@
 
 ## Unversioned
 
+- Minor: Added "Open 7TV user in browser" and "Open channel in browser" (same as left-click) when right-clicking the profile picture in a usercard (#400)
+
+## 7.5.5-beta.1
+
 - Major: Added experimental Kick support (#351, #353, #354, #355, #356, #357, #360, #362, #367, #368, #369, #371, #373, #378, #379, #380, #381, #382, #383, #386, #387, #388, #390, #391, #395)
 - Minor: Increased radius of drop-shadows in paints to match the browser extension (#339, a4a86c9ca6e1bccf9253dce75bdfe838c15e71fd)
 - Bugfix: Fixed 7TV users with multiple connections to the same platform not having cosmetics applied on all connected accounts (#389)

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -76,6 +76,7 @@ constexpr QStringView SEVENTV_TWITCH_USER_API =
     u"https://7tv.io/v3/users/twitch/%1";
 constexpr QStringView SEVENTV_KICK_USER_API =
     u"https://7tv.io/v3/users/kick/%1";
+constexpr QStringView SEVENTV_USER_PAGE = u"https://7tv.app/users/";
 
 using namespace chatterino;
 
@@ -373,6 +374,9 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                                 split->setChannel(channel);
                                 container->insertSplit(split);
                             });
+
+                        this->appendCommonProfileActions(menu);
+
                         menu->popup(QCursor::pos());
                         menu->raise();
                     }
@@ -1307,8 +1311,10 @@ void UserInfoPopup::loadSevenTVAvatar(const QString &userID, bool isKick)
                 return;
             }
 
-            auto root = result.parseJson();
-            auto url = root["user"].toObject()["avatar_url"].toString();
+            const auto root = result.parseJson();
+            const auto userObj = root["user"].toObject();
+            this->seventvUserID_ = userObj["id"].toString();
+            auto url = userObj["avatar_url"].toString();
 
             if (url.isEmpty())
             {
@@ -1643,6 +1649,9 @@ void UserInfoPopup::onKickProfilePictureClick(Qt::MouseButton button)
                     getApp()->getKickChatServer()->getOrCreate(username));
                 container->insertSplit(split);
             });
+
+            this->appendCommonProfileActions(menu);
+
             menu->popup(QCursor::pos());
             menu->raise();
         }
@@ -1660,6 +1669,17 @@ QStringView UserInfoPopup::platformName() const
         return u"Kick";
     }
     return u"Twitch";
+}
+
+void UserInfoPopup::appendCommonProfileActions(QMenu *menu)
+{
+    if (!this->seventvUserID_.isEmpty())
+    {
+        menu->addAction(
+            "Open 7TV user in browser", this, [id = this->seventvUserID_] {
+                QDesktopServices::openUrl(QUrl(SEVENTV_USER_PAGE + id));
+            });
+    }
 }
 
 //

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1687,7 +1687,7 @@ void UserInfoPopup::appendCommonProfileActions(QMenu *menu)
     {
         menu->addAction(
             "Open 7TV user in browser", this, [id = this->seventvUserID_] {
-                QDesktopServices::openUrl(QUrl(SEVENTV_USER_PAGE + id));
+                QDesktopServices::openUrl(QUrl(SEVENTV_USER_PAGE % id));
             });
     }
 }

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -377,7 +377,7 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                             });
 
                         menu->addAction(
-                            "Open channel in browser", [channelURL] {
+                            "Open channel in browser", this, [channelURL] {
                                 QDesktopServices::openUrl(channelURL);
                             });
 
@@ -1656,7 +1656,7 @@ void UserInfoPopup::onKickProfilePictureClick(Qt::MouseButton button)
                 container->insertSplit(split);
             });
 
-            menu->addAction("Open channel in browser", [channelURL] {
+            menu->addAction("Open channel in browser", this, [channelURL] {
                 QDesktopServices::openUrl(channelURL);
             });
 

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -314,12 +314,13 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                     return;
                 }
 
+                QUrl channelURL("https://www.twitch.tv/" +
+                                this->userName_.toLower());
+
                 switch (button)
                 {
                     case Qt::LeftButton: {
-                        QDesktopServices::openUrl(
-                            QUrl("https://www.twitch.tv/" +
-                                 this->userName_.toLower()));
+                        QDesktopServices::openUrl(channelURL);
                     }
                     break;
 
@@ -373,6 +374,11 @@ UserInfoPopup::UserInfoPopup(bool closeAutomatically, Split *split)
                                 Split *split = new Split(container);
                                 split->setChannel(channel);
                                 container->insertSplit(split);
+                            });
+
+                        menu->addAction(
+                            "Open channel in browser", [channelURL] {
+                                QDesktopServices::openUrl(channelURL);
                             });
 
                         this->appendCommonProfileActions(menu);
@@ -1594,12 +1600,12 @@ void UserInfoPopup::updateKickUserData()
 void UserInfoPopup::onKickProfilePictureClick(Qt::MouseButton button)
 {
     assert(this->isKick_);
+    auto channelURL = QUrl("https://kick.com/" + this->kickUserSlug_);
 
     switch (button)
     {
         case Qt::LeftButton: {
-            QDesktopServices::openUrl(
-                QUrl("https://kick.com/" + this->kickUserSlug_));
+            QDesktopServices::openUrl(channelURL);
         }
         break;
 
@@ -1648,6 +1654,10 @@ void UserInfoPopup::onKickProfilePictureClick(Qt::MouseButton button)
                 split->setChannel(
                     getApp()->getKickChatServer()->getOrCreate(username));
                 container->insertSplit(split);
+            });
+
+            menu->addAction("Open channel in browser", [channelURL] {
+                QDesktopServices::openUrl(channelURL);
             });
 
             this->appendCommonProfileActions(menu);

--- a/src/widgets/dialogs/UserInfoPopup.hpp
+++ b/src/widgets/dialogs/UserInfoPopup.hpp
@@ -74,6 +74,8 @@ private:
 
     QStringView platformName() const;
 
+    void appendCommonProfileActions(QMenu *menu);
+
     bool isMod_{};
     bool isBroadcaster_{};
 
@@ -84,6 +86,7 @@ private:
     QString avatarUrl_;
     QString helixAvatarUrl_;
     QString seventvAvatarUrl_;
+    QString seventvUserID_;
 
     QString kickUserSlug_;
 


### PR DESCRIPTION
Adds "Open 7TV user in browser" and "Open channel in browser" (same as left-click) when right-clicking the profile picture.

Closes #399.