### PR TITLE
fix(kick): Resolve users and channels in /mentions

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Cache conan packages
         uses: actions/cache@v5
         with:
-          key: ${{ runner.os }}-conan-user-${{ hashFiles('**/conanfile.py') }}${{ env.C2_CONAN_CACHE_SUFFIX }}
+          key: ${{ runner.os }}-${{ runner.arch }}-conan-user-${{ hashFiles('**/conanfile.py') }}-QT6
           path: ~/.conan2/
 
       - name: Install Conan

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -3015,7 +3015,8 @@ void ChannelView::hideEvent(QHideEvent * /*event*/)
 }
 
 void ChannelView::showUserInfoPopup(const QString &userName,
-                                    QString alternativePopoutChannel)
+                                    MessagePlatform platform,
+                                    const QString &alternativePopoutChannel)
 {
     if (!this->split_)
     {
@@ -3031,7 +3032,7 @@ void ChannelView::showUserInfoPopup(const QString &userName,
     auto openingChannel = this->hasSourceChannel() ? this->sourceChannel_
                                                    : this->underlyingChannel_;
     ChannelPtr contextChannel;
-    if (openingChannel && openingChannel->isKickChannel())
+    if (openingChannel && platform == MessagePlatform::Kick)
     {
         contextChannel =
             getApp()->getKickChatServer()->findBySlug(alternativePopoutChannel);
@@ -3094,7 +3095,8 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::UserWhisper:
         case Link::UserInfo: {
             auto user = link.value;
-            this->showUserInfoPopup(user, layout->getMessage()->channelName);
+            this->showUserInfoPopup(user, layout->getMessage()->platform,
+                                    layout->getMessage()->channelName);
         }
         break;
 
@@ -3164,6 +3166,12 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
                 openPages.push_back(
                     static_cast<SplitContainer *>(nb.getPageAt(i)));
             }
+            QStringView searchName = link.value;
+            bool searchKickChannel = link.value.startsWith(u":kick:");
+            if (searchKickChannel)
+            {
+                searchName = searchName.sliced(sizeof(":kick:") - 1);
+            }
 
             for (auto *page : openPages)
             {
@@ -3171,9 +3179,11 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
 
                 // Search for channel matching link in page/split container
                 // TODO(zneix): Consider opening a channel if it's closed (?)
-                auto it = std::find_if(
-                    splits.begin(), splits.end(), [link](Split *split) {
-                        return split->getChannel()->getName() == link.value;
+                auto it = std::ranges::find_if(
+                    splits, [searchName, searchKickChannel](Split *split) {
+                        return split->getChannel()->getName() == searchName &&
+                               split->getChannel()->isKickChannel() ==
+                                   searchKickChannel;
                     });
 
                 if (it != splits.end())

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -33,6 +33,8 @@ enum class HighlightState;
 class Channel;
 using ChannelPtr = std::shared_ptr<Channel>;
 
+enum class MessagePlatform : uint8_t;
+
 struct Message;
 using MessagePtr = std::shared_ptr<const Message>;
 
@@ -196,8 +198,8 @@ public:
      * @param userName The login name of the user
      * @param alternativePopoutChannel Optional parameter containing the channel name to use for context
      **/
-    void showUserInfoPopup(const QString &userName,
-                           QString alternativePopoutChannel = QString());
+    void showUserInfoPopup(const QString &userName, MessagePlatform platform,
+                           const QString &alternativePopoutChannel = {});
 
     /**
      * @brief This method is meant to be used when filtering out channels.

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1253,7 +1253,8 @@ void Split::openChatterList()
 
     QObject::connect(chatterDock, &ChatterListWidget::userClicked,
                      [this](const QString &userLogin) {
-                         this->view_->showUserInfoPopup(userLogin);
+                         this->view_->showUserInfoPopup(
+                             userLogin, MessagePlatform::AnyOrTwitch);
                      });
 
     chatterDock->resize(chatterListWidth, chatterListHeight);


### PR DESCRIPTION
- Fixes a bug where Twitch usercards would open in `/mentions`
- Fixes a bug where Channels weren't found when clicking on the channel name.