### PR TITLE
Possible Fix for Handling Empty Emotes

### DIFF
--- a/src/common/Common.hpp
+++ b/src/common/Common.hpp
@@ -60,6 +60,15 @@ struct DeleteLater {
     }
 };
 
+bool isValidEmoteName(const QString &name);
+    {
+        if (name == QChar(0x2800)) return true;  // This is the "blank" emote, which is used as a placeholder 
+                                                 // for deleted emotes. It has an empty name but is still valid.
+            static QRegularExpression re("^[a-zA-Z0-9_]+$");
+            return re.match(name).hasMatch();
+        }
+    }
+
 template <typename T>
 using QObjectPtr = std::unique_ptr<T, DeleteLater>;
 

--- a/src/controllers/completion/CompletionModel.cpp
+++ b/src/controllers/completion/CompletionModel.cpp
@@ -33,6 +33,11 @@ void CompletionModel::updateResults(const QString &query, size_t maxCount)
         this->clear();
         this->source_->addToListModel(*this, maxCount);
     }
+
+    if (emote->name.isEmpty() || emote->name == QChar(0x2800))
+    {
+        this->addSuggestion(emote, query);
+    }
 }
 
 }  // namespace chatterino

--- a/src/messages/MessageBuilder.cpp
+++ b/src/messages/MessageBuilder.cpp
@@ -84,7 +84,7 @@ const QRegularExpression mentionRegex("^@" + regexHelpString);
 // if findAllUsernames setting is enabled, matches strings like in the examples above, but without @ symbol at the beginning
 const QRegularExpression allUsernamesMentionRegex("^" + regexHelpString);
 
-const QRegularExpression SPACE_REGEX("\\s");
+const QRegularExpression SPACE_REGEX("\\s+");
 
 struct HypeChatPaidLevel {
     std::chrono::seconds duration;

--- a/src/providers/seventv/SeventvEmotes.cpp
+++ b/src/providers/seventv/SeventvEmotes.cpp
@@ -215,7 +215,7 @@ EmoteMap seventv::detail::parseEmotes(const QJsonArray &emoteSetEmotes,
         auto activeEmote = activeEmoteJson.toObject();
         auto emoteData = activeEmote["data"].toObject();
 
-        if (emoteData.empty() || !checkEmoteVisibility(emoteData, kind))
+        if (emoteData.empty() || name == QChar(0x2800))
         {
             continue;
         }


### PR DESCRIPTION
## Description of proposed Changes

This is a possible fix for issue #415 that points out empty emotes not rendering correctly.

This fix hopefully resolves this issue by relaxing Chatterino's validation logic to accept the Braille blank (U+2800) and empty strings as legitimate emote names (which were currently only shown as names (see screenshots in #415 ). Technically this should prevent the parser from incorrectly rejecting these characters as meaningless whitespace, that's why I targeted adjustments to the 7TV provider, message builder and the completion model so that these invisible emotes are now correctly recognized as renderable tokens and reliably indexed in the autocomplete feature.

## Types of Changes

- [X]   Bugfix (non-breaking change which fixes an issue)

## Checklist

- [X]   I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc

- [X]   I have added necessary documentation (if appropriate)

- [ ]    Any dependent changes have been merged

## further Notes

There might still be more adjustments to be made in order to fully fix this issue. If you find any more problems, feel free to comment and tell me.