### PR TITLE
feat(multichannel): Infer message context more often

### DIFF
--- a/src/util/MultiChannel.cpp
+++ b/src/util/MultiChannel.cpp
@@ -2,6 +2,7 @@
 
 #include "Application.hpp"
 #include "common/WindowDescriptors.hpp"
+#include "messages/Message.hpp"
 #include "providers/kick/KickChatServer.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "util/QCompareTransparent.hpp"
@@ -370,6 +371,18 @@ void MultiChannel::setComputedName(const QString &name)
     }
     this->computedName = name;
     this->displayNameChanged.invoke();
+}
+
+bool platformMatches(MessagePlatform lhs, MultiChannel::Platform rhs) noexcept
+{
+    switch (lhs)
+    {
+        case MessagePlatform::AnyOrTwitch:
+            return rhs == MultiChannel::Platform::Twitch;
+        case MessagePlatform::Kick:
+            return rhs == MultiChannel::Platform::Kick;
+    }
+    return false;
 }
 
 }  // namespace chatterino

--- a/src/util/MultiChannel.hpp
+++ b/src/util/MultiChannel.hpp
@@ -11,6 +11,8 @@ namespace chatterino {
 
 struct ChildChannelDescriptor;
 
+enum class MessagePlatform : uint8_t;
+
 class MultiChannel : public Channel
 {
 public:
@@ -83,6 +85,8 @@ private:
     MultiChannelIndicatorMode indicatorMode_ =
         MultiChannelIndicatorMode::PlatformBadgeIfUnselected;
 };
+
+bool platformMatches(MessagePlatform lhs, MultiChannel::Platform rhs) noexcept;
 
 }  // namespace chatterino
 

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -192,10 +192,11 @@ ReplyThreadPopup::ReplyThreadPopup(bool closeAutomatically, Split *split)
     }
 }
 
-void ReplyThreadPopup::setThread(std::shared_ptr<MessageThread> thread)
+void ReplyThreadPopup::setThread(std::shared_ptr<MessageThread> thread,
+                                 std::weak_ptr<Channel> channel)
 {
     this->thread_ = std::move(thread);
-    this->ui_.replyInput->setReply(this->thread_->root());
+    this->ui_.replyInput->setReply(this->thread_->root(), std::move(channel));
     this->addMessagesFromThread();
     this->updateInputUI();
 

--- a/src/widgets/dialogs/ReplyThreadPopup.hpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.hpp
@@ -18,6 +18,7 @@ namespace chatterino {
 class MessageThread;
 class Split;
 class SplitInput;
+class Channel;
 
 class ReplyThreadPopup final : public DraggablePopup
 {
@@ -30,7 +31,8 @@ public:
      */
     explicit ReplyThreadPopup(bool closeAutomatically, Split *split);
 
-    void setThread(std::shared_ptr<MessageThread> thread);
+    void setThread(std::shared_ptr<MessageThread> thread,
+                   std::weak_ptr<Channel> channel);
     void giveFocus(Qt::FocusReason reason);
 
 protected:

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -944,6 +944,80 @@ ChannelPtr ChannelView::selectedChannel() const
     return this->underlyingChannel_;
 }
 
+ChannelPtr ChannelView::inferChannel(const Message &msg,
+                                     InferChannel mode) const
+{
+    ChannelPtr base = this->underlyingChannel_;
+    switch (mode)
+    {
+        case InferChannel::UnderlyingOnly:
+            break;
+        case InferChannel::SourceChannelIfAvailable: {
+            if (this->hasSourceChannel())
+            {
+                base = this->sourceChannel_;
+            }
+        }
+        break;
+        case InferChannel::SearchParentIfAvailable: {
+            auto *searchPopup =
+                dynamic_cast<SearchPopup *>(this->parentWidget());
+            if (searchPopup != nullptr)
+            {
+                auto *split =
+                    dynamic_cast<Split *>(searchPopup->parentWidget());
+                if (split != nullptr)
+                {
+                    base = split->getChannel();
+                }
+            }
+        }
+        break;
+    }
+
+    auto *mc = dynamic_cast<MultiChannel *>(base.get());
+    if (!mc)
+    {
+        return base;
+    }
+
+    const auto *active = mc->activeChannel();
+    auto matches = [&](const MultiChannel::ChildChannel &chan) {
+        if (!platformMatches(msg.platform, chan.platform))
+        {
+            return false;
+        }
+        QStringView nameView = msg.channelName;
+        bool kc = nameView.startsWith(u":kick:");
+        if (kc)
+        {
+            nameView = nameView.sliced(sizeof(":kick:") - 1);
+        }
+        return nameView.compare(chan.channel->getName(), Qt::CaseInsensitive) ==
+               0;
+    };
+
+    if (active && matches(*active))
+    {
+        return active->channel;
+    }
+
+    for (const auto &chan : mc->channels())
+    {
+        if (matches(chan))
+        {
+            return chan.channel;
+        }
+    }
+
+    // This shouldn't happen, we should always find a channel.
+    if (active)
+    {
+        return active->channel;
+    }
+    return this->underlyingChannel_;
+}
+
 std::pair<Channel *, MessageElementFlags> ChannelView::getMultiChannelInfo()
     const
 {
@@ -2814,24 +2888,22 @@ void ChannelView::addMessageContextMenuItems(QMenu *menu,
         }
     }
 
-    if (!layout->getMessage()->id.isEmpty() &&
-        this->underlyingChannel_->hasModRights())
+    auto chan = this->inferChannel(*layout->getMessage());
+    if (!layout->getMessage()->id.isEmpty() && chan->hasModRights())
     {
         menu->addSeparator();
         auto *moderateAction = menu->addAction("Mo&derate");
         auto *moderateMenu = new QMenu(menu);
         moderateAction->setMenu(moderateMenu);
         moderateMenu->addAction(
-            "&Delete message", [this, id = layout->getMessage()->id] {
-                auto *twitchChannel = dynamic_cast<TwitchChannel *>(
-                    this->underlyingChannel_.get());
+            "&Delete message", [chan, id = layout->getMessage()->id] {
+                auto *twitchChannel = dynamic_cast<TwitchChannel *>(chan.get());
                 if (twitchChannel)
                 {
                     twitchChannel->deleteMessagesAs(
                         id, getApp()->getAccounts()->twitch.getCurrent().get());
                 }
-                else if (auto *kc = dynamic_cast<KickChannel *>(
-                             this->underlyingChannel_.get()))
+                else if (auto *kc = dynamic_cast<KickChannel *>(chan.get()))
                 {
                     kc->deleteMessage(id);
                 }
@@ -2991,14 +3063,7 @@ void ChannelView::addCommandExecutionContextMenuItems(
 
             /* Search popups and user message history's underlyingChannels aren't of type TwitchChannel, but
              * we would still like to execute commands from them. Use their source channel instead if applicable. */
-            if (this->hasSourceChannel())
-            {
-                channel = this->sourceChannel();
-            }
-            else
-            {
-                channel = this->underlyingChannel_;
-            }
+            channel = this->inferChannel(*layout->getMessage());
             auto *split = dynamic_cast<Split *>(this->parentWidget());
             QString userText;
             if (split)
@@ -3097,8 +3162,8 @@ void ChannelView::showUserInfoPopup(const QString &userName,
     auto *userPopup =
         new UserInfoPopup(getSettings()->autoCloseUserPopup, this->split_);
 
-    auto openingChannel = this->hasSourceChannel() ? this->sourceChannel_
-                                                   : this->underlyingChannel_;
+    auto openingChannel =
+        this->hasSourceChannel() ? this->sourceChannel_ : this->sourceChannel();
     ChannelPtr contextChannel;
     if (openingChannel && platform == MessagePlatform::Kick)
     {
@@ -3183,18 +3248,8 @@ void ChannelView::handleLinkClick(QMouseEvent *event, const Link &link,
         case Link::UserAction: {
             QString value = link.value;
 
-            ChannelPtr channel = this->underlyingChannel_;
-            auto *searchPopup =
-                dynamic_cast<SearchPopup *>(this->parentWidget());
-            if (searchPopup != nullptr)
-            {
-                auto *split =
-                    dynamic_cast<Split *>(searchPopup->parentWidget());
-                if (split != nullptr)
-                {
-                    channel = split->getChannel();
-                }
-            }
+            ChannelPtr channel = this->inferChannel(
+                *layout->getMessage(), InferChannel::SearchParentIfAvailable);
 
             // Execute command clicking a moderator button
             value = getApp()->getCommands()->execCustomCommand(
@@ -3424,11 +3479,10 @@ void ChannelView::setInputReply(const MessagePtr &message)
         return;
     }
 
+    auto chan = this->inferChannel(*message);
     if (!message->replyThread)
     {
         // Message did not already have a thread attached, try to find or create one
-        auto chan = this->selectedChannel();
-
         auto *tc = dynamic_cast<TwitchChannel *>(chan.get());
         auto *kc = dynamic_cast<KickChannel *>(chan.get());
 
@@ -3449,7 +3503,7 @@ void ChannelView::setInputReply(const MessagePtr &message)
         }
     }
 
-    this->split_->setInputReply(message);
+    this->split_->setInputReply(message, chan);
 }
 
 void ChannelView::showReplyThreadPopup(const MessagePtr &message)
@@ -3470,7 +3524,7 @@ void ChannelView::showReplyThreadPopup(const MessagePtr &message)
     auto *popup =
         new ReplyThreadPopup(getSettings()->autoCloseThreadPopup, this->split_);
 
-    popup->setThread(message->replyThread);
+    popup->setThread(message->replyThread, this->inferChannel(*message));
 
     QPoint offset(int(150 * this->scale()), int(70 * this->scale()));
     popup->showAndMoveTo(QCursor::pos() - offset,

--- a/src/widgets/helper/ChannelView.cpp
+++ b/src/widgets/helper/ChannelView.cpp
@@ -3162,8 +3162,8 @@ void ChannelView::showUserInfoPopup(const QString &userName,
     auto *userPopup =
         new UserInfoPopup(getSettings()->autoCloseUserPopup, this->split_);
 
-    auto openingChannel =
-        this->hasSourceChannel() ? this->sourceChannel_ : this->sourceChannel();
+    auto openingChannel = this->hasSourceChannel() ? this->sourceChannel_
+                                                   : this->selectedChannel();
     ChannelPtr contextChannel;
     if (openingChannel && platform == MessagePlatform::Kick)
     {

--- a/src/widgets/helper/ChannelView.hpp
+++ b/src/widgets/helper/ChannelView.hpp
@@ -165,6 +165,18 @@ public:
     /// for MultiChannels.
     ChannelPtr selectedChannel() const;
 
+    enum class InferChannel : uint8_t {
+        UnderlyingOnly,
+        SourceChannelIfAvailable,
+        SearchParentIfAvailable,
+    };
+
+    /// Infer the channel this message originates from.
+    /// In MultiChannels, this uses the best matching channel.
+    ChannelPtr inferChannel(
+        const Message &msg,
+        InferChannel mode = InferChannel::SourceChannelIfAvailable) const;
+
     /// @brief Set the channel this view is displaying
     ///
     /// @see #underlyingChannel()

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -1428,9 +1428,10 @@ void Split::drag()
     stopDraggingSplit();
 }
 
-void Split::setInputReply(const MessagePtr &reply)
+void Split::setInputReply(const MessagePtr &reply,
+                          std::weak_ptr<Channel> channel)
 {
-    this->input_->setReply(reply);
+    this->input_->setReply(reply, std::move(channel));
 }
 
 void Split::unpause()

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -84,7 +84,7 @@ public:
 
     void setContainer(SplitContainer *container);
 
-    void setInputReply(const MessagePtr &reply);
+    void setInputReply(const MessagePtr &reply, std::weak_ptr<Channel> channel);
 
     // This is called on window focus lost
     void unpause();

--- a/src/widgets/splits/SplitInput.cpp
+++ b/src/widgets/splits/SplitInput.cpp
@@ -251,7 +251,7 @@ void SplitInput::initLayout()
 
     // clear input and remove reply thread
     QObject::connect(this->ui_.cancelReplyButton, &Button::leftClicked, [this] {
-        this->setReply(nullptr);
+        this->setReply(nullptr, {});
     });
 
     // Forward selection change signal
@@ -398,7 +398,15 @@ void SplitInput::openEmotePopup()
 
 QString SplitInput::handleSendMessage(const std::vector<QString> &arguments)
 {
-    auto c = this->split_->getSelectedChannel();
+    ChannelPtr c;
+    if (this->replyTarget_)
+    {
+        c = this->replyChannel_.lock();
+    }
+    if (!c)
+    {
+        c = this->split_->getSelectedChannel();
+    }
     if (c == nullptr)
     {
         return "";
@@ -1276,7 +1284,7 @@ void SplitInput::giveFocus(Qt::FocusReason reason)
     this->ui_.textEdit->setFocus(reason);
 }
 
-void SplitInput::setReply(MessagePtr target)
+void SplitInput::setReply(MessagePtr target, std::weak_ptr<Channel> channel)
 {
     auto oldParent = this->replyTarget_;
     if (this->enableInlineReplying_ && oldParent)
@@ -1296,6 +1304,7 @@ void SplitInput::setReply(MessagePtr target)
     if (target != nullptr)
     {
         this->replyTarget_ = std::move(target);
+        this->replyChannel_ = std::move(channel);
 
         if (this->enableInlineReplying_)
         {
@@ -1346,6 +1355,7 @@ void SplitInput::setReply(MessagePtr target)
     else
     {
         this->replyTarget_.reset();
+        this->replyChannel_.reset();
 
         if (this->enableInlineReplying_)
         {

--- a/src/widgets/splits/SplitInput.hpp
+++ b/src/widgets/splits/SplitInput.hpp
@@ -31,6 +31,7 @@ class ResizingTextEdit;
 class ChannelView;
 class SvgButton;
 class SpellCheckHighlighter;
+class Channel;
 enum class CompletionKind;
 
 class SplitInput : public BaseWidget
@@ -49,7 +50,7 @@ public:
     QString getInputText() const;
     void insertText(const QString &text);
 
-    void setReply(MessagePtr target);
+    void setReply(MessagePtr target, std::weak_ptr<Channel> channel);
     void setPlaceholderText(const QString &text);
 
     /**
@@ -173,6 +174,7 @@ protected:
     } ui_;
 
     MessagePtr replyTarget_ = nullptr;
+    std::weak_ptr<Channel> replyChannel_;
     bool enableInlineReplying_;
 
     pajlada::Signals::SignalHolder managedConnections_;

--- a/tests/snapshots/IrcMessageHandler/links.json
+++ b/tests/snapshots/IrcMessageHandler/links.json
@@ -88,6 +88,7 @@
                     "trailingSpace": true,
                     "type": "LinkElement",
                     "words": [
+                        ""
                     ]
                 },
                 {
@@ -120,6 +121,7 @@
                     "trailingSpace": true,
                     "type": "LinkElement",
                     "words": [
+                        ""
                     ]
                 },
                 {
@@ -137,6 +139,7 @@
                     "trailingSpace": false,
                     "type": "LinkElement",
                     "words": [
+                        ""
                     ]
                 },
                 {
@@ -184,6 +187,7 @@
                     "trailingSpace": false,
                     "type": "LinkElement",
                     "words": [
+                        ""
                     ]
                 },
                 {

--- a/tests/src/SplitInput.cpp
+++ b/tests/src/SplitInput.cpp
@@ -98,7 +98,7 @@ TEST_P(SplitInputTest, Reply)
     auto *message = new Message();
     message->displayName = "forsen";
     auto reply = MessagePtr(message);
-    this->input.setReply(reply);
+    this->input.setReply(reply, {});
     QString actual = this->input.getInputText();
     ASSERT_EQ(expected, actual) << "Input text after setReply should be '"
                                 << expected << "', but got '" << actual << "'";


### PR DESCRIPTION
This includes the following improvements:

- Use correct channel when using `Moderate > Delete Message`
- Use correct channel when using commands from the context menu
- Allow replying to any message - correct channel is automatically inferred (no longer requires switching context)
