### PR TITLE
feat(kick): support v2 badges, sub emote images, and history

### DIFF
--- a/src/providers/kick/KickApi.cpp
+++ b/src/providers/kick/KickApi.cpp
@@ -347,6 +347,14 @@ void KickApi::privateEmotesInChannel(
     autoSlugify(u"https://kick.com/emotes"_s, std::move(cb), username);
 }
 
+void KickApi::privateChannelHistory(uint64_t channelID,
+                                    Callback<BoostJsonObject> cb)
+{
+    autoSlugify(u"https://web.kick.com/api/v1/chat/" %
+                    QString::number(channelID) % "/history",
+                std::move(cb));
+}
+
 void KickApi::sendMessage(uint64_t broadcasterUserID, const QString &message,
                           const QString &replyToMessageID, Callback<void> cb)
 {

--- a/src/providers/kick/KickApi.cpp
+++ b/src/providers/kick/KickApi.cpp
@@ -228,6 +228,12 @@ KickPrivateChatroomInfo::KickPrivateChatroomInfo(BoostJsonObject obj)
     }
 }
 
+KickPrivateChannelSubBadge::KickPrivateChannelSubBadge(BoostJsonObject obj)
+    : months(static_cast<unsigned>(obj["months"].toUint64()))
+    , badgeImageUrl(obj["badge_image"]["src"].toQString())
+{
+}
+
 KickPrivateChannelInfo::KickPrivateChannelInfo(BoostJsonObject obj)
     : channelID(obj["id"].toUint64())
     , followersCount(obj["followers_count"].toUint64())
@@ -235,6 +241,10 @@ KickPrivateChannelInfo::KickPrivateChannelInfo(BoostJsonObject obj)
     , user(obj["user"].toObject())
     , chatroom(obj["chatroom"].toObject())
 {
+    for (auto badge : obj["subscriber_badges"].toArray())
+    {
+        this->subBadges.emplace_back(badge.toObject());
+    }
 }
 
 KickPrivateUserInChannelInfo::KickPrivateUserInChannelInfo(BoostJsonObject obj)

--- a/src/providers/kick/KickApi.hpp
+++ b/src/providers/kick/KickApi.hpp
@@ -124,6 +124,9 @@ public:
         const QString &username,
         Callback<std::vector<KickPrivateEmoteSetInfo>> cb);
 
+    static void privateChannelHistory(uint64_t channelID,
+                                      Callback<BoostJsonObject> cb);
+
     void sendMessage(uint64_t broadcasterUserID, const QString &message,
                      const QString &replyToMessageID, Callback<void> cb);
 

--- a/src/providers/kick/KickApi.hpp
+++ b/src/providers/kick/KickApi.hpp
@@ -36,6 +36,13 @@ struct KickPrivateChatroomInfo {
     std::optional<std::chrono::minutes> followersModeDuration;
 };
 
+struct KickPrivateChannelSubBadge {
+    KickPrivateChannelSubBadge(BoostJsonObject obj);
+
+    unsigned months;
+    QString badgeImageUrl;
+};
+
 struct KickPrivateChannelInfo {
     KickPrivateChannelInfo(BoostJsonObject obj);
 
@@ -44,6 +51,7 @@ struct KickPrivateChannelInfo {
     QString slug;
     KickPrivateUserInfo user;
     KickPrivateChatroomInfo chatroom;
+    std::vector<KickPrivateChannelSubBadge> subBadges;
 };
 
 struct KickPrivateUserInChannelInfo {

--- a/src/providers/kick/KickBadges.cpp
+++ b/src/providers/kick/KickBadges.cpp
@@ -1,7 +1,9 @@
 #include "providers/kick/KickBadges.hpp"
 
 #include "debug/AssertInGuiThread.hpp"
+#include "util/QStringHash.hpp"
 
+#include <boost/unordered/unordered_flat_map.hpp>
 #include <magic_enum/magic_enum.hpp>
 
 namespace {
@@ -157,6 +159,43 @@ std::pair<EmotePtr, MessageElementFlag> KickBadges::lookup(
     }
 
     return entry;
+}
+
+std::pair<EmotePtr, MessageElementFlag> KickBadges::getV2Cached(
+    BoostJsonObject badgeObj)
+{
+    static boost::unordered_flat_map<QString, EmotePtr> cache;
+
+    auto imageUrl = badgeObj["image_url"].toQString();
+    auto it = cache.find(imageUrl);
+    if (it != cache.end())
+    {
+        return {it->second, MessageElementFlag::BadgeVanity};
+    }
+
+    QString name;
+    auto origName = badgeObj["name"].toStringView();
+    if (origName == "level")
+    {
+        auto level = QString::number(badgeObj["metadata"]["level"].toUint64());
+        name = u"Level " % level;
+    }
+    else
+    {
+        name = QString::fromUtf8(origName.data(),
+                                 static_cast<qsizetype>(origName.size()));
+    }
+
+    auto emote = std::make_shared<const Emote>(Emote{
+        .name = {name},
+        .images =
+            ImageSet{
+                Image::fromAutoscaledUrl({imageUrl}, 18),
+            },
+        .tooltip = Tooltip{name},
+    });
+    cache.emplace(imageUrl, emote);
+    return {emote, MessageElementFlag::BadgeVanity};
 }
 
 }  // namespace chatterino

--- a/src/providers/kick/KickBadges.hpp
+++ b/src/providers/kick/KickBadges.hpp
@@ -2,6 +2,7 @@
 
 #include "messages/Emote.hpp"
 #include "messages/MessageElement.hpp"
+#include "util/BoostJsonWrap.hpp"
 
 #include <string_view>
 
@@ -12,6 +13,9 @@ class KickBadges
 public:
     static std::pair<EmotePtr, MessageElementFlag> lookup(
         std::string_view name);
+
+    static std::pair<EmotePtr, MessageElementFlag> getV2Cached(
+        BoostJsonObject badgeObj);
 };
 
 }  // namespace chatterino

--- a/src/providers/kick/KickChannel.cpp
+++ b/src/providers/kick/KickChannel.cpp
@@ -469,6 +469,43 @@ void KickChannel::setSendWait(std::chrono::seconds waitTime)
     }
 }
 
+EmotePtr KickChannel::getSubBadge(unsigned months)
+{
+    auto cIt = this->subBadges_.find(months);
+    if (cIt != this->subBadges_.end())
+    {
+        return cIt->second;
+    }
+    auto baseIt = this->subBadgeImages_.lower_bound(months);
+    if (baseIt == this->subBadgeImages_.end())
+    {
+        return {};
+    }
+    if (baseIt->first != months)
+    {
+        if (baseIt == this->subBadgeImages_.begin())
+        {
+            return {};
+        }
+        --baseIt;
+    }
+
+    auto name = [&]() -> QString {
+        if (months == 1)
+        {
+            return u"1-Month Subscriber"_s;
+        }
+        return QString::number(months) % u"-Months Subscriber";
+    }();
+    auto emote = std::make_shared<const Emote>(Emote{
+        .name = {name},
+        .images = ImageSet{baseIt->second},
+        .tooltip = Tooltip{name},
+    });
+    this->subBadges_.emplace(months, emote);
+    return emote;
+}
+
 void KickChannel::messageRemovedFromStart(const MessagePtr &msg)
 {
     if (msg->replyThread)
@@ -502,6 +539,7 @@ void KickChannel::resolveChannelInfo()
                 return;
             }
 
+            self->initSubBadges(res->subBadges);
             self->slug_ = res->slug;
             self->setUserInfo(UserInit{
                 .roomID = res->chatroom.roomID,
@@ -864,6 +902,18 @@ void KickChannel::emitSendWait()
     else
     {
         this->sendWaitUpdate.invoke(formatTime(remaining, 2));
+    }
+}
+
+void KickChannel::initSubBadges(
+    std::span<const KickPrivateChannelSubBadge> infos)
+{
+    this->subBadges_.clear();
+    this->subBadgeImages_.clear();
+    for (const auto &info : infos)
+    {
+        this->subBadgeImages_.emplace(
+            info.months, Image::fromAutoscaledUrl({info.badgeImageUrl}, 18));
     }
 }
 

--- a/src/providers/kick/KickChannel.cpp
+++ b/src/providers/kick/KickChannel.cpp
@@ -937,9 +937,14 @@ void KickChannel::loadChannelHistory()
             }
             BoostJsonObject obj(*res);
             std::vector<MessagePtr> messages;
-            for (auto msg :
-                 obj["data"]["messages"].toArray() | std::views::reverse)
+            auto arr = obj["data"]["messages"].toArray();
+            if (arr.empty())
             {
+                return;
+            }
+            for (auto i = static_cast<qsizetype>(arr.size() - 1); i >= 0; --i)
+            {
+                auto msg = arr.at(static_cast<size_t>(i));
                 if (msg["type"].toStringView() != "message")
                 {
                     continue;

--- a/src/providers/kick/KickChannel.cpp
+++ b/src/providers/kick/KickChannel.cpp
@@ -17,12 +17,14 @@
 #include "providers/kick/KickApi.hpp"
 #include "providers/kick/KickChatServer.hpp"
 #include "providers/kick/KickLiveUpdates.hpp"
+#include "providers/kick/KickMessageBuilder.hpp"
 #include "providers/seventv/eventapi/Dispatch.hpp"
 #include "providers/seventv/SeventvAPI.hpp"
 #include "providers/seventv/SeventvEmotes.hpp"
 #include "providers/seventv/SeventvEventAPI.hpp"
 #include "providers/twitch/TwitchIrcServer.hpp"
 #include "singletons/Settings.hpp"
+#include "util/BoostJsonWrap.hpp"
 #include "util/FormatTime.hpp"
 #include "util/Helpers.hpp"
 #include "util/PostToThread.hpp"
@@ -559,6 +561,7 @@ void KickChannel::resolveChannelInfo()
                 .slowModeDuration = res->chatroom.slowModeDuration,
                 .followersModeDuration = res->chatroom.followersModeDuration,
             });
+            self->loadChannelHistory();
         });
 }
 
@@ -915,6 +918,43 @@ void KickChannel::initSubBadges(
         this->subBadgeImages_.emplace(
             info.months, Image::fromAutoscaledUrl({info.badgeImageUrl}, 18));
     }
+}
+
+void KickChannel::loadChannelHistory()
+{
+    KickApi::privateChannelHistory(
+        this->channelID_, [weak = this->weakFromThis()](const auto &res) {
+            auto self = weak.lock();
+            if (!self)
+            {
+                return;
+            }
+            if (!res)
+            {
+                qCWarning(chatterinoKick)
+                    << *self << "Failed to load channel history" << res.error();
+                return;
+            }
+            BoostJsonObject obj(*res);
+            std::vector<MessagePtr> messages;
+            for (auto msg :
+                 obj["data"]["messages"].toArray() | std::views::reverse)
+            {
+                if (msg["type"].toStringView() != "message")
+                {
+                    continue;
+                }
+                auto [ptr, highlight] = KickMessageBuilder::makeChatMessage(
+                    self.get(), msg.toObject());
+                messages.emplace_back(std::move(ptr));
+            }
+
+            // Just use the Twitch setting here.
+            if (getSettings()->loadTwitchMessageHistoryOnConnect)
+            {
+                self->fillInMissingMessages(messages);
+            }
+        });
 }
 
 QDebug operator<<(QDebug dbg, const KickChannel &chan)

--- a/src/providers/kick/KickChannel.hpp
+++ b/src/providers/kick/KickChannel.hpp
@@ -182,6 +182,8 @@ private:
 
     void initSubBadges(std::span<const KickPrivateChannelSubBadge> infos);
 
+    void loadChannelHistory();
+
     // Kick usually calls this username
     QString displayName_;
     // The name in the URL (replaces non-alphanumeric characters with dashes)

--- a/src/providers/kick/KickChannel.hpp
+++ b/src/providers/kick/KickChannel.hpp
@@ -7,6 +7,7 @@
 #include <pajlada/signals/signal.hpp>
 
 #include <chrono>
+#include <map>
 #include <queue>
 #include <unordered_map>
 
@@ -28,6 +29,7 @@ using EmotePtr = std::shared_ptr<const Emote>;
 struct EmoteName;
 
 struct KickChannelInfo;
+struct KickPrivateChannelSubBadge;
 
 class KickChannel : public Channel, public ChannelChatters
 {
@@ -142,6 +144,8 @@ public:
     pajlada::Signals::Signal<const QString &> sendWaitUpdate;
     void setSendWait(std::chrono::seconds waitTime);
 
+    EmotePtr getSubBadge(unsigned months);
+
     friend QDebug operator<<(QDebug dbg, const KickChannel &chan);
 
 protected:
@@ -176,6 +180,8 @@ private:
 
     void emitSendWait();
 
+    void initSubBadges(std::span<const KickPrivateChannelSubBadge> infos);
+
     // Kick usually calls this username
     QString displayName_;
     // The name in the URL (replaces non-alphanumeric characters with dashes)
@@ -208,6 +214,9 @@ private:
     bool isVip_ = false;
 
     StreamData streamData_;
+
+    std::map<unsigned, ImagePtr> subBadgeImages_;
+    std::unordered_map<unsigned, EmotePtr> subBadges_;
 };
 
 }  // namespace chatterino

--- a/src/providers/kick/KickLiveController.cpp
+++ b/src/providers/kick/KickLiveController.cpp
@@ -15,7 +15,7 @@ namespace {
 using namespace std::chrono_literals;
 
 constexpr auto IMMEDIATE_DELAY = 1s;
-constexpr auto REFRESH_INTERVAL = 1min;
+constexpr auto REFRESH_INTERVAL = 30s;
 
 constexpr size_t CHUNK_SIZE = 50;
 

--- a/src/providers/kick/KickMessageBuilder.cpp
+++ b/src/providers/kick/KickMessageBuilder.cpp
@@ -346,6 +346,17 @@ void appendKickBadges(KickMessageBuilder &builder, BoostJsonArray badges)
     for (auto badgeObj : badges)
     {
         auto ty = badgeObj["type"].toStringView();
+        if (ty == "subscriber")
+        {
+            auto badge =
+                builder.channel()->getSubBadge(badgeObj["count"].toUint64(1));
+            if (badge)
+            {
+                builder.emplace<BadgeElement>(
+                    std::move(badge), MessageElementFlag::BadgeSubscription);
+                continue;
+            }
+        }
         auto [emote, flag] = KickBadges::lookup(ty);
         if (!emote)
         {

--- a/src/providers/kick/KickMessageBuilder.cpp
+++ b/src/providers/kick/KickMessageBuilder.cpp
@@ -373,6 +373,22 @@ void appendKickBadges(KickMessageBuilder &builder, BoostJsonArray badges)
     }
 }
 
+void appendKickV2Badges(KickMessageBuilder &builder, BoostJsonArray badges)
+{
+    // FIXME: respect order
+    for (auto badgeObj : badges)
+    {
+        bool selected = badgeObj["selected"].toBool();
+        if (!selected)
+        {
+            continue;
+        }
+        auto [emote, flag] = KickBadges::getV2Cached(badgeObj.toObject());
+
+        builder.emplace<BadgeElement>(emote, flag);
+    }
+}
+
 void appendSeventvBadge(KickMessageBuilder &builder)
 {
     auto badge = getApp()->getSeventvBadges()->getKickBadge(builder.senderID);
@@ -488,6 +504,7 @@ std::pair<MessagePtrMut, HighlightAlert> KickMessageBuilder::makeChatMessage(
     builder.emplace<TimestampElement>(builder->serverReceivedTime.time());
     builder.emplace<TwitchModerationElement>();
 
+    appendKickV2Badges(builder, identity["badges_v2"].toArray());
     appendKickBadges(builder, identity["badges"].toArray());
     appendSeventvBadge(builder);
 


### PR DESCRIPTION
v2 badges are for the new levels. Sub images are already in the channel info endpoint, so just use them. History is a new endpoint, but very useful.
