### PR TITLE
fix(multichannel): show reply text, room modes and live status

### DIFF
--- a/src/util/MultiChannel.cpp
+++ b/src/util/MultiChannel.cpp
@@ -11,6 +11,7 @@
 #include <QUuid>
 #include <QVarLengthArray>
 
+#include <algorithm>
 #include <set>
 
 namespace {
@@ -297,22 +298,16 @@ bool MultiChannel::hasHighRateLimit() const
 
 bool MultiChannel::isLive() const
 {
-    const auto *active = this->activeChannel();
-    if (active)
-    {
-        return active->channel->isLive();
-    }
-    return false;
+    return std::ranges::any_of(this->channels_, [](const auto &c) {
+        return c.channel->isLive();
+    });
 }
 
 bool MultiChannel::isRerun() const
 {
-    const auto *active = this->activeChannel();
-    if (active)
-    {
-        return active->channel->isRerun();
-    }
-    return false;
+    return std::ranges::any_of(this->channels_, [](const auto &c) {
+        return c.channel->isRerun();
+    });
 }
 
 bool MultiChannel::shouldIgnoreHighlights() const

--- a/src/widgets/dialogs/ReplyThreadPopup.cpp
+++ b/src/widgets/dialogs/ReplyThreadPopup.cpp
@@ -11,6 +11,7 @@
 #include "controllers/hotkeys/HotkeyController.hpp"
 #include "messages/Message.hpp"
 #include "messages/MessageThread.hpp"
+#include "providers/kick/KickAccount.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
 #include "singletons/Settings.hpp"
@@ -282,30 +283,41 @@ void ReplyThreadPopup::addMessagesFromThread()
 
 void ReplyThreadPopup::updateInputUI()
 {
-    auto channel = this->split_->getChannel();
+    auto channel = this->split_->getSelectedChannel();
     // Bail out if not a twitch channel.
     // Special twitch channels will hide their reply input box.
-    if (!channel || !channel->isTwitchChannel())
+    if (!channel || !channel->isTwitchOrKickChannel())
     {
         return;
     }
 
     this->ui_.replyInput->setVisible(channel->isWritable());
 
-    auto user = getApp()->getAccounts()->twitch.getCurrent();
+    QString name;
+    if (channel->isTwitchChannel())
+    {
+        auto user = getApp()->getAccounts()->twitch.getCurrent();
+        if (!user->isAnon())
+        {
+            name = user->getUserName();
+        }
+    }
+    else
+    {
+        auto user = getApp()->getAccounts()->kick.current();
+        if (!user->isAnonymous())
+        {
+            name = user->username();
+        }
+    }
     QString placeholderText;
-
-    if (user->isAnon())
+    if (name.isEmpty())
     {
         placeholderText = QStringLiteral("Log in to send messages...");
     }
     else
     {
-        placeholderText = QStringLiteral("Reply as %1...")
-                              .arg(getApp()
-                                       ->getAccounts()
-                                       ->twitch.getCurrent()
-                                       ->getUserName());
+        placeholderText = QStringLiteral("Reply as %1...").arg(name);
     }
 
     this->ui_.replyInput->setPlaceholderText(placeholderText);

--- a/src/widgets/splits/Split.cpp
+++ b/src/widgets/splits/Split.cpp
@@ -933,13 +933,9 @@ void Split::setChannel(IndirectChannel newChannel)
 
     this->view_->setChannel(newChannel.get());
 
-    this->usermodeChangedConnection_.disconnect();
-    this->roomModeChangedConnection_.disconnect();
     this->indirectChannelChangedConnection_.disconnect();
     this->channelSignalHolder_.clear();
 
-    TwitchChannel *tc = dynamic_cast<TwitchChannel *>(newChannel.get().get());
-    auto *kc = dynamic_cast<KickChannel *>(newChannel.get().get());
     auto *mc = dynamic_cast<MultiChannel *>(newChannel.get().get());
 
     if (mc)
@@ -947,40 +943,10 @@ void Split::setChannel(IndirectChannel newChannel)
         this->channelSignalHolder_.managedConnect(
             mc->activeChannelChanged, [this] {
                 this->updateInputPlaceholder();
+                this->updateChannelConnections();
             });
     }
-    else if (tc != nullptr)
-    {
-        this->usermodeChangedConnection_ = tc->userStateChanged.connect([this] {
-            this->header_->updateIcons();
-            this->header_->updateRoomModes();
-        });
-
-        this->roomModeChangedConnection_ = tc->roomModesChanged.connect([this] {
-            this->header_->updateRoomModes();
-        });
-
-        this->channelSignalHolder_.managedConnect(
-            tc->sendWaitUpdate, [this](const QString &text) {
-                this->getInput().setSendWaitStatus(text);
-            });
-    }
-    else if (kc != nullptr)
-    {
-        this->usermodeChangedConnection_ = kc->userStateChanged.connect([this] {
-            this->header_->updateIcons();
-            this->header_->updateRoomModes();
-        });
-
-        this->roomModeChangedConnection_ = kc->roomModesChanged.connect([this] {
-            this->header_->updateRoomModes();
-        });
-
-        this->channelSignalHolder_.managedConnect(
-            kc->sendWaitUpdate, [this](const QString &text) {
-                this->getInput().setSendWaitStatus(text);
-            });
-    }
+    this->updateChannelConnections();
 
     this->indirectChannelChangedConnection_ =
         newChannel.getChannelChanged().connect([this] {
@@ -1018,6 +984,56 @@ void Split::setChannel(IndirectChannel newChannel)
 
     // Queue up save because: Split channel changed
     getApp()->getWindows()->queueSave();
+}
+
+void Split::updateChannelConnections()
+{
+    this->usermodeChangedConnection_.disconnect();
+    this->roomModeChangedConnection_.disconnect();
+    this->sendWaitConnection_ = pajlada::Signals::ScopedConnection{};
+    this->getInput().setSendWaitStatus({});
+
+    auto *channel = this->channel_.get().get();
+    auto *mc = dynamic_cast<MultiChannel *>(channel);
+    if (mc)
+    {
+        channel = mc->activeChannel()->channel.get();
+    }
+
+    auto *tc = dynamic_cast<TwitchChannel *>(channel);
+    auto *kc = dynamic_cast<KickChannel *>(channel);
+    if (tc)
+    {
+        this->usermodeChangedConnection_ = tc->userStateChanged.connect([this] {
+            this->header_->updateIcons();
+            this->header_->updateRoomModes();
+        });
+
+        this->roomModeChangedConnection_ = tc->roomModesChanged.connect([this] {
+            this->header_->updateRoomModes();
+        });
+
+        this->sendWaitConnection_ =
+            tc->sendWaitUpdate.connect([this](const QString &text) {
+                this->getInput().setSendWaitStatus(text);
+            });
+    }
+    else if (kc != nullptr)
+    {
+        this->usermodeChangedConnection_ = kc->userStateChanged.connect([this] {
+            this->header_->updateIcons();
+            this->header_->updateRoomModes();
+        });
+
+        this->roomModeChangedConnection_ = kc->roomModesChanged.connect([this] {
+            this->header_->updateRoomModes();
+        });
+
+        this->sendWaitConnection_ =
+            kc->sendWaitUpdate.connect([this](const QString &text) {
+                this->getInput().setSendWaitStatus(text);
+            });
+    }
 }
 
 void Split::setModerationMode(bool value)

--- a/src/widgets/splits/Split.hpp
+++ b/src/widgets/splits/Split.hpp
@@ -156,6 +156,8 @@ private:
 
     void refreshInputState(const QString &inputText);
 
+    void updateChannelConnections();
+
     IndirectChannel channel_;
 
     bool moderationMode_{};
@@ -177,6 +179,7 @@ private:
     pajlada::Signals::Connection channelIDChangedConnection_;
     pajlada::Signals::Connection usermodeChangedConnection_;
     pajlada::Signals::Connection roomModeChangedConnection_;
+    pajlada::Signals::ScopedConnection sendWaitConnection_;
 
     pajlada::Signals::Connection indirectChannelChangedConnection_;
 


### PR DESCRIPTION
- The live status in the notebook only showed the status of the selected channel. I think it should show if any channel is live (much like splits).
- Show the input text in reply popups correctly.
- Show room modes at the start.