### PR TITLE
feat(kick): Show Chatterino badges based on 7TV connections

### DIFF
--- a/mocks/include/mocks/ChatterinoBadges.hpp
+++ b/mocks/include/mocks/ChatterinoBadges.hpp
@@ -24,6 +24,15 @@ public:
         this->users.emplace(std::move(id), std::move(emote));
     }
 
+    EmotePtr getKickBadge(uint64_t /* kickID */) override
+    {
+        return {};
+    }
+
+    void setKickMapping(const QString &twitchID, uint64_t kickID) override
+    {
+    }
+
 private:
     std::unordered_map<UserId, EmotePtr> users;
 };

--- a/src/providers/chatterino/ChatterinoBadges.cpp
+++ b/src/providers/chatterino/ChatterinoBadges.cpp
@@ -33,6 +33,27 @@ std::optional<EmotePtr> ChatterinoBadges::getBadge(const UserId &id)
     return std::nullopt;
 }
 
+EmotePtr ChatterinoBadges::getKickBadge(uint64_t kickID)
+{
+    auto it = this->kickMapping.find(kickID);
+    if (it != this->kickMapping.end())
+    {
+        return this->emotes[it->second];
+    }
+    return {};
+}
+
+void ChatterinoBadges::setKickMapping(const QString &twitchID, uint64_t kickID)
+{
+    // Lookup by Twitch ID first. Assume that most users don't have a Chatterino badge.
+    auto existing = this->badgeMap.find(twitchID);
+    if (existing == this->badgeMap.end())
+    {
+        return;
+    }
+    this->kickMapping.emplace(kickID, existing->second);
+}
+
 void ChatterinoBadges::loadChatterinoBadges()
 {
     static QUrl url("https://api.chatterino.com/badges");

--- a/src/providers/chatterino/ChatterinoBadges.hpp
+++ b/src/providers/chatterino/ChatterinoBadges.hpp
@@ -29,6 +29,8 @@ public:
     IChatterinoBadges &operator=(IChatterinoBadges &&) = delete;
 
     virtual std::optional<EmotePtr> getBadge(const UserId &id) = 0;
+    virtual EmotePtr getKickBadge(uint64_t kickID) = 0;
+    virtual void setKickMapping(const QString &twitchID, uint64_t kickID) = 0;
 };
 
 class ChatterinoBadges : public IChatterinoBadges
@@ -44,6 +46,10 @@ public:
      */
     std::optional<EmotePtr> getBadge(const UserId &id) override;
 
+    EmotePtr getKickBadge(uint64_t kickID) override;
+
+    void setKickMapping(const QString &twitchID, uint64_t kickID) override;
+
 private:
     void loadChatterinoBadges();
 
@@ -54,6 +60,8 @@ private:
      * Guarded by mutex_
      */
     std::unordered_map<QString, int> badgeMap;
+
+    std::unordered_map<uint64_t, int> kickMapping;
 
     /**
      * Keeps a list of badges.

--- a/src/providers/kick/KickMessageBuilder.cpp
+++ b/src/providers/kick/KickMessageBuilder.cpp
@@ -10,6 +10,7 @@
 #include "messages/MessageElement.hpp"
 #include "messages/MessageThread.hpp"
 #include "providers/bttv/BttvEmotes.hpp"
+#include "providers/chatterino/ChatterinoBadges.hpp"
 #include "providers/emoji/Emojis.hpp"
 #include "providers/ffz/FfzEmotes.hpp"
 #include "providers/kick/KickAccount.hpp"
@@ -382,6 +383,19 @@ void appendSeventvBadge(KickMessageBuilder &builder)
     }
 }
 
+void appendChatterinoBadge(KickMessageBuilder &builder)
+{
+    if (auto badge =
+            getApp()->getChatterinoBadges()->getKickBadge(builder.senderID))
+    {
+        builder.emplace<BadgeElement>(badge,
+                                      MessageElementFlag::BadgeChatterino);
+
+        /// e.g. "chatterino:Chatterino Top donator"
+        builder->externalBadges.emplace_back(badge->name.string);
+    }
+}
+
 HighlightAlert processHighlights(KickMessageBuilder &builder,
                                  const MessageParseArgs &args)
 {
@@ -489,6 +503,7 @@ std::pair<MessagePtrMut, HighlightAlert> KickMessageBuilder::makeChatMessage(
     builder.emplace<TwitchModerationElement>();
 
     appendKickBadges(builder, identity["badges"].toArray());
+    appendChatterinoBadge(builder);
     appendSeventvBadge(builder);
 
     builder.appendUsername(identity);

--- a/src/providers/seventv/eventapi/Client.cpp
+++ b/src/providers/seventv/eventapi/Client.cpp
@@ -5,6 +5,7 @@
 #include "providers/seventv/eventapi/Client.hpp"
 
 #include "Application.hpp"
+#include "providers/chatterino/ChatterinoBadges.hpp"
 #include "providers/seventv/eventapi/Dispatch.hpp"
 #include "providers/seventv/eventapi/Message.hpp"
 #include "providers/seventv/eventapi/Subscription.hpp"
@@ -12,7 +13,9 @@
 #include "providers/seventv/SeventvEventAPI.hpp"
 #include "providers/seventv/SeventvPaints.hpp"
 #include "providers/seventv/SeventvPersonalEmotes.hpp"
+#include "util/PostToThread.hpp"
 #include "util/QMagicEnum.hpp"
+#include "util/Variant.hpp"
 
 #include <QJsonArray>
 
@@ -344,6 +347,35 @@ void Client::onEntitlementCreate(
     if (!app)
     {
         return;  // shutting down
+    }
+
+    if (entitlement.connections.size() >= 2)
+    {
+        QString twitchID;
+        uint64_t kickID = 0;
+        for (const auto &conn : entitlement.connections)
+        {
+            std::visit(variant::Overloaded{
+                           [&](const KickUser &kick) {
+                               kickID = kick.id;
+                           },
+                           [&](const TwitchUser &twitch) {
+                               twitchID = twitch.id;
+                           },
+                       },
+                       conn);
+        }
+        if (!twitchID.isEmpty() && kickID != 0)
+        {
+            postToThread([twitchID, kickID] {
+                auto *app = tryGetApp();
+                if (app)
+                {
+                    app->getChatterinoBadges()->setKickMapping(twitchID,
+                                                               kickID);
+                }
+            });
+        }
     }
 
     auto *badges = app->getSeventvBadges();


### PR DESCRIPTION
The Chatterino badges don't include Kick IDs, but we know a mapping based on the 7TV user connections.