### PR TITLE
feat(kick): support `/usercard id:<id>`

### DIFF
--- a/src/controllers/commands/builtin/Misc.cpp
+++ b/src/controllers/commands/builtin/Misc.cpp
@@ -10,6 +10,7 @@
 #include "controllers/commands/CommandContext.hpp"
 #include "controllers/userdata/UserDataController.hpp"
 #include "providers/kick/KickChannel.hpp"
+#include "providers/kick/KickChatServer.hpp"
 #include "providers/twitch/api/Helix.hpp"
 #include "providers/twitch/TwitchAccount.hpp"
 #include "providers/twitch/TwitchChannel.hpp"
@@ -711,8 +712,13 @@ QString openUsercard(const CommandContext &ctx)
         QString channelName = ctx.words[2];
         stripChannelName(channelName);
 
-        ChannelPtr channelTemp =
-            getApp()->getTwitch()->getChannelOrEmpty(channelName);
+        auto channelTemp = [&]() -> ChannelPtr {
+            if (channel->isKickChannel())
+            {
+                return getApp()->getKickChatServer()->findBySlug(channelName);
+            }
+            return getApp()->getTwitch()->getChannelOrEmpty(channelName);
+        }();
 
         if (channelTemp->isEmpty())
         {

--- a/src/providers/kick/KickApi.cpp
+++ b/src/providers/kick/KickApi.cpp
@@ -290,6 +290,7 @@ KickChannelInfo::KickChannelInfo(BoostJsonObject obj)
     , category(obj["category"].toObject())
     , stream(obj["stream"].toObject())
     , streamTitle(obj["stream_title"].toQString())
+    , slug(obj["slug"].toQString())
 {
 }
 

--- a/src/providers/kick/KickApi.hpp
+++ b/src/providers/kick/KickApi.hpp
@@ -103,6 +103,7 @@ struct KickChannelInfo {
     KickCategoryInfo category;
     KickStreamInfo stream;
     QString streamTitle;
+    QString slug;
 };
 
 class KickApi

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1272,7 +1272,8 @@ void UserInfoPopup::loadAvatar(const QString &userID, const QString &pictureURL,
     QFile cacheFile(filename);
     if (cacheFile.exists())
     {
-        cacheFile.open(QIODevice::ReadOnly);
+        // In this case, readAll will just return empty data.
+        std::ignore = cacheFile.open(QIODevice::ReadOnly);
         QPixmap avatar{};
 
         avatar.loadFromData(cacheFile.readAll());

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1554,54 +1554,85 @@ void UserInfoPopup::updateKickUserData()
         self->ui_.notesAdd->setEnabled(true);
     };
 
-    // FIXME: this doesn't support opening by user ID
+    auto fetchChannelInfo = [self = QPointer(this), onChannelFetched,
+                             onChannelFetchFailed](const QString &userName) {
+        KickApi::privateChannelInfo(
+            userName,
+            [self, onChannelFetched, onChannelFetchFailed](const auto &res) {
+                if (!self)
+                {
+                    return;
+                }
+                if (res)
+                {
+                    onChannelFetched(self.get(), *res);
+                }
+                else
+                {
+                    qCDebug(chatterinoKick)
+                        << "Channel fetch failed" << res.error();
+                    onChannelFetchFailed(self.get());
+                }
+            });
+    };
+    auto fetchUserInChannelInfo =
+        [self = QPointer(this),
+         channelName =
+             this->underlyingChannel_->getName()](const QString &userName) {
+            KickApi::privateUserInChannelInfo(
+                userName, channelName, [self](const auto &res) {
+                    if (!self || !res)
+                    {
+                        return;
+                    }
 
-    KickApi::privateChannelInfo(
-        this->userName_, [self = QPointer(this), onChannelFetched,
-                          onChannelFetchFailed](const auto &res) {
-            if (!self)
-            {
-                return;
-            }
-            if (res)
-            {
-                onChannelFetched(self.get(), *res);
-            }
-            else
-            {
-                qCDebug(chatterinoKick)
-                    << "Channel fetch failed" << res.error();
-                onChannelFetchFailed(self.get());
-            }
-        });
-    KickApi::privateUserInChannelInfo(
-        this->userName_, this->underlyingChannel_->getName(),
-        [self = QPointer(this)](const auto &res) {
-            if (!self || !res)
-            {
-                return;
-            }
+                    if (res->followingSince)
+                    {
+                        QString followingSince =
+                            res->followingSince->date().toString(Qt::ISODate);
+                        self->ui_.followageLabel->setText("❤ Following since " +
+                                                          followingSince);
+                        self->ui_.followageLabel->setToolTip(
+                            formatLongFriendlyDuration(
+                                *res->followingSince,
+                                QDateTime::currentDateTimeUtc()) +
+                            u" ago"_s);
+                        self->ui_.followageLabel->setMouseTracking(true);
+                    }
 
-            if (res->followingSince)
-            {
-                QString followingSince =
-                    res->followingSince->date().toString(Qt::ISODate);
-                self->ui_.followageLabel->setText("❤ Following since " +
-                                                  followingSince);
-                self->ui_.followageLabel->setToolTip(
-                    formatLongFriendlyDuration(
-                        *res->followingSince, QDateTime::currentDateTimeUtc()) +
-                    u" ago"_s);
-                self->ui_.followageLabel->setMouseTracking(true);
-            }
+                    if (res->subscriptionMonths)
+                    {
+                        self->ui_.subageLabel->setText(
+                            QString("★ Subscribed for %2 months")
+                                .arg(*res->subscriptionMonths));
+                    }
+                });
+        };
 
-            if (res->subscriptionMonths)
-            {
-                self->ui_.subageLabel->setText(
-                    QString("★ Subscribed for %2 months")
-                        .arg(*res->subscriptionMonths));
-            }
-        });
+    if (!this->userId_.isEmpty() && this->userName_.isEmpty())
+    {
+        std::array ids{this->userId_.toULongLong()};
+        getKickApi()->getChannels(
+            ids, [self = QPointer(this), onChannelFetchFailed, fetchChannelInfo,
+                  fetchUserInChannelInfo](const auto &res) {
+                if (!self)
+                {
+                    return;
+                }
+                if (!res || res->size() != 1)
+                {
+                    onChannelFetchFailed(self);
+                    return;
+                }
+                fetchChannelInfo((*res)[0].slug);
+                fetchUserInChannelInfo((*res)[0].slug);
+            });
+    }
+    else
+    {
+        fetchChannelInfo(this->userName_);
+        fetchUserInChannelInfo(this->userName_);
+    }
 
     this->ui_.block->setEnabled(false);
     this->ui_.ignoreHighlights->setEnabled(false);

--- a/src/widgets/dialogs/UserInfoPopup.cpp
+++ b/src/widgets/dialogs/UserInfoPopup.cpp
@@ -1611,7 +1611,7 @@ void UserInfoPopup::updateKickUserData()
 
     if (!this->userId_.isEmpty() && this->userName_.isEmpty())
     {
-        std::array ids{this->userId_.toULongLong()};
+        std::array ids{static_cast<uint64_t>(this->userId_.toULongLong())};
         getKickApi()->getChannels(
             ids, [self = QPointer(this), onChannelFetchFailed, fetchChannelInfo,
                   fetchUserInChannelInfo](const auto &res) {


### PR DESCRIPTION
We didn't support this before, but I can see this being useful. Unfortunately, this is slower than going by the name, because we need to resolve the slug first.

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->
