### PR TITLE
fix: show parted users

### DIFF
--- a/src/providers/twitch/IrcMessageHandler.cpp
+++ b/src/providers/twitch/IrcMessageHandler.cpp
@@ -1069,7 +1069,7 @@ void IrcMessageHandler::handlePartMessage(Communi::IrcMessage *message)
         }
         return message->nick() == ANONYMOUS_USERNAME;
     }();
-    if (ownUser && getSettings()->showParts.getValue())
+    if (!ownUser && getSettings()->showParts.getValue())
     {
         twitchChannel->addPartedUser(message->nick(), twitchChannel->isMod(),
                                      twitchChannel->isBroadcaster());


### PR DESCRIPTION
<!--
    Make sure you read the contribution guidelines:
    https://github.com/Chatterino/chatterino2/blob/master/CONTRIBUTING.md

    Please include a summary of what you've changed and what issue is fixed.
    In the case of a bug fix, please include steps to reproduce the bug, so the pull request can be tested.
    If this PR fixes an issue on GitHub, mention this here to automatically close it: "Fixes #1234.".
-->

Fixes typo from 06d36606b917a825fb3e71fbaebf5c3b5660c5be, allowing you to see parted users again

<!--
Leave this at the bottom

Co-authored-by: -
Tested-by: -
Reported-by: -
Reviewed-by: -
Parent-pr: -
-->


